### PR TITLE
feat: onboarding

### DIFF
--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -30,7 +30,7 @@ export default function HomeScreen() {
 
   // 데이터 로딩이 완료되었을 때 공지사항 목록을 보여줍니다.
   return (
-    <View className="flex-1 bg-white">
+    <View className="flex-1 bg-gray-50">
       <FlatList
         data={notices}
         renderItem={({ item }) => <NoticeContent item={item} />}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -7,10 +7,19 @@ import { Drawer } from 'expo-router/drawer'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 
 import HomeDrawer from '@/components/layout/HomeDrawer/HomeDrawer'
+import { useOnboarding } from '@/hooks/useOnboarding'
 import { queryClient } from '@/utils/queryClient'
 
 // _를 붙이면 일반 페이지가 아니라 레이아웃(layout), 슬롯(slot), API 라우트 등 특별한 기능을 하는 파일로 취급됩니다.
 export default function RootLayout() {
+  // 온보딩 완료 여부 확인
+  const { isOnboardingComplete } = useOnboarding()
+
+  // 로딩 중일 때는 빈 화면 표시
+  if (isOnboardingComplete === null) {
+    return <GestureHandlerRootView style={{ flex: 1 }} />
+  }
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>

--- a/src/app/onboarding/index.tsx
+++ b/src/app/onboarding/index.tsx
@@ -1,0 +1,400 @@
+import { useState } from 'react'
+
+import { Ionicons } from '@expo/vector-icons'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useRouter } from 'expo-router'
+import { View, Text, TouchableOpacity, ScrollView, Switch } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+import { DEPARTMENTS_BY_COLLEGE } from '@/constants/collge'
+import { NOTIFICATION_KEYWORDS } from '@/constants/keyword'
+import { useNotificationStore } from '@/store/notificationStore'
+
+const ONBOARDING_KEY = 'hasSeenOnboarding'
+const TOTAL_PAGES = 5
+
+export default function OnboardingScreen() {
+  const router = useRouter()
+  const [currentPage, setCurrentPage] = useState(0)
+
+  // Zustand 스토어에서 상태와 액션 가져오기
+  const {
+    selectedCollege,
+    selectedDepartment,
+    selectedKeywords,
+    notificationEnabled,
+    setSelectedCollege,
+    setSelectedDepartment,
+    toggleKeyword,
+    setNotificationEnabled,
+  } = useNotificationStore()
+
+  const handleComplete = async () => {
+    try {
+      // 온보딩 완료 표시 저장 (설정은 이미 Zustand persist로 자동 저장됨)
+      await AsyncStorage.setItem(ONBOARDING_KEY, 'true')
+      console.log('온보딩 완료! 저장된 알림 설정:', {
+        college: selectedCollege,
+        department: selectedDepartment,
+        keywords: selectedKeywords,
+        notification: notificationEnabled,
+      })
+      router.replace('/(tabs)')
+    } catch (error) {
+      console.error('온보딩 완료 저장 실패:', error)
+    }
+  }
+
+  const handleNext = () => {
+    if (currentPage < TOTAL_PAGES - 1) {
+      setCurrentPage(currentPage + 1)
+    } else {
+      handleComplete()
+    }
+  }
+
+  const handleBack = () => {
+    if (currentPage > 0) {
+      setCurrentPage(currentPage - 1)
+    }
+  }
+
+  const renderPage = () => {
+    switch (currentPage) {
+      case 0:
+        // 환영 페이지
+        return (
+          <View className="flex-1 items-center justify-center px-8">
+            <Text className="mb-4 text-center text-3xl font-bold text-gray-900">
+              반가워요 👋
+            </Text>
+            <Text className="text-center text-lg leading-7 text-gray-600">
+              동의대 공지를 한눈에 확인할 수 있어요
+            </Text>
+          </View>
+        )
+
+      case 1:
+        // 단과대 선택 페이지
+        return (
+          <View className="flex-1 px-6">
+            <View className="mb-6 mt-4">
+              <Text className="mb-2 text-center text-3xl font-bold text-gray-900">
+                어떤 단과대 소속이신가요?
+              </Text>
+              <Text className="text-center text-base text-gray-600">
+                단과대를 먼저 골라야 학과를 선택할 수 있어요
+              </Text>
+            </View>
+
+            <ScrollView
+              className="flex-1"
+              showsVerticalScrollIndicator={false}
+              contentContainerClassName="pb-8"
+            >
+              <View className="gap-3">
+                {Object.entries(DEPARTMENTS_BY_COLLEGE).map(
+                  ([key, college]) => (
+                    <TouchableOpacity
+                      key={key}
+                      onPress={() => setSelectedCollege(key)}
+                      className={`rounded-xl border-2 p-4 ${
+                        selectedCollege === key
+                          ? 'border-[#093a87] bg-blue-50'
+                          : 'border-gray-200 bg-white'
+                      }`}
+                    >
+                      <View className="flex-row items-center justify-between">
+                        <Text
+                          className={`text-lg font-semibold ${
+                            selectedCollege === key
+                              ? 'text-[#093a87]'
+                              : 'text-gray-900'
+                          }`}
+                        >
+                          {college.title}
+                        </Text>
+                        {selectedCollege === key && (
+                          <Ionicons
+                            name="checkmark-circle"
+                            size={24}
+                            color="#093a87"
+                          />
+                        )}
+                      </View>
+                    </TouchableOpacity>
+                  )
+                )}
+              </View>
+            </ScrollView>
+          </View>
+        )
+
+      case 2:
+        // 학과 선택 페이지
+        return (
+          <View className="flex-1 px-6">
+            <View className="mb-6 mt-4">
+              <Text className="mb-2 text-center text-3xl font-bold text-gray-900">
+                어떤 학과에 다니시나요?
+              </Text>
+              <Text className="text-center text-base text-gray-600">
+                {selectedCollege
+                  ? DEPARTMENTS_BY_COLLEGE[
+                      selectedCollege as keyof typeof DEPARTMENTS_BY_COLLEGE
+                    ].title
+                  : '먼저 단과대학을 선택해주세요'}
+              </Text>
+            </View>
+
+            {selectedCollege ? (
+              <ScrollView
+                className="flex-1"
+                showsVerticalScrollIndicator={false}
+                contentContainerClassName="pb-8"
+              >
+                <View className="gap-3">
+                  {DEPARTMENTS_BY_COLLEGE[
+                    selectedCollege as keyof typeof DEPARTMENTS_BY_COLLEGE
+                  ].departments.map((dept) => (
+                    <TouchableOpacity
+                      key={dept.id}
+                      onPress={() => setSelectedDepartment(dept.name)}
+                      className={`rounded-xl border-2 p-4 ${
+                        selectedDepartment === dept.name
+                          ? 'border-[#093a87] bg-blue-50'
+                          : 'border-gray-200 bg-white'
+                      }`}
+                    >
+                      <View className="flex-row items-center justify-between">
+                        <Text
+                          className={`text-base font-medium ${
+                            selectedDepartment === dept.name
+                              ? 'text-[#093a87]'
+                              : 'text-gray-900'
+                          }`}
+                        >
+                          {dept.name}
+                        </Text>
+                        {selectedDepartment === dept.name && (
+                          <Ionicons
+                            name="checkmark-circle"
+                            size={24}
+                            color="#093a87"
+                          />
+                        )}
+                      </View>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </ScrollView>
+            ) : (
+              <View className="flex-1 items-center justify-center">
+                <Text className="text-gray-400">
+                  이전 단계에서 단과대학을 선택해주세요
+                </Text>
+              </View>
+            )}
+          </View>
+        )
+
+      case 3:
+        // 관심 키워드 선택 페이지
+        return (
+          <View className="flex-1 px-6">
+            <View className="mb-6 mt-4">
+              <Text className="mb-2 text-center text-3xl font-bold text-gray-900">
+                어떤 주제의 공지를{'\n'}자주 보고 싶으신가요?
+              </Text>
+              <Text className="text-center text-base text-gray-600">
+                선택한 주제의 새 공지를 먼저 알려드릴게요
+              </Text>
+            </View>
+
+            <ScrollView
+              className="flex-1"
+              showsVerticalScrollIndicator={false}
+              contentContainerClassName="pb-8"
+            >
+              <View className="gap-3">
+                {Object.entries(NOTIFICATION_KEYWORDS).map(([key, keyword]) => {
+                  const isSelected = selectedKeywords.includes(key)
+                  return (
+                    <TouchableOpacity
+                      key={key}
+                      onPress={() => toggleKeyword(key)}
+                      className={`rounded-xl border-2 p-4 ${
+                        isSelected
+                          ? 'border-[#093a87] bg-blue-50'
+                          : 'border-gray-200 bg-white'
+                      }`}
+                    >
+                      <View className="flex-row items-center justify-between">
+                        <View className="flex-1">
+                          <Text
+                            className={`mb-1 text-lg font-semibold ${
+                              isSelected ? 'text-[#093a87]' : 'text-gray-900'
+                            }`}
+                          >
+                            {keyword.title}
+                          </Text>
+                          <Text className="text-sm text-gray-600">
+                            {keyword.description}
+                          </Text>
+                        </View>
+                        {isSelected && (
+                          <Ionicons
+                            name="checkmark-circle"
+                            size={24}
+                            color="#093a87"
+                          />
+                        )}
+                      </View>
+                    </TouchableOpacity>
+                  )
+                })}
+              </View>
+            </ScrollView>
+          </View>
+        )
+
+      case 4:
+        // 알림 설정 및 완료 페이지
+        return (
+          <View className="flex-1 px-6">
+            <View className="mb-8 mt-4">
+              <Text className="mb-2 text-center text-3xl font-bold text-gray-900">
+                새 공지를 알림으로 받아볼까요?
+              </Text>
+              <Text className="text-center text-base text-gray-600">
+                놓치지 않도록 바로 알려드릴게요
+              </Text>
+            </View>
+
+            <View className="gap-4">
+              {/* 알림 토글 */}
+              <View className="rounded-xl border border-gray-200 bg-white p-5">
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-1">
+                    <Text className="mb-1 text-lg font-semibold text-gray-900">
+                      🔔 푸시 알림 받기
+                    </Text>
+                    <Text className="text-sm text-gray-600">
+                      새로운 공지사항을 실시간으로 알려드려요
+                    </Text>
+                  </View>
+                  <Switch
+                    value={notificationEnabled}
+                    onValueChange={setNotificationEnabled}
+                    trackColor={{ false: '#D1D5DB', true: '#93C5FD' }}
+                    thumbColor={notificationEnabled ? '#093a87' : '#F3F4F6'}
+                  />
+                </View>
+              </View>
+
+              {/* 선택한 정보 요약 */}
+              <View className="gap-3 rounded-xl border border-gray-200 bg-gray-50 p-5">
+                {selectedDepartment && (
+                  <View className="flex-row items-center gap-2">
+                    <Ionicons name="school" size={18} color="#6B7280" />
+                    <Text className="text-sm text-gray-700">
+                      {selectedDepartment}
+                    </Text>
+                  </View>
+                )}
+
+                {selectedKeywords.length > 0 && (
+                  <View className="flex-row items-start gap-2">
+                    <Ionicons
+                      name="pricetag"
+                      size={18}
+                      color="#6B7280"
+                      style={{ marginTop: 2 }}
+                    />
+                    <View className="flex-1 flex-row flex-wrap gap-2">
+                      {selectedKeywords.map((key) => (
+                        <View
+                          key={key}
+                          className="rounded-full bg-blue-100 px-3 py-1"
+                        >
+                          <Text className="text-xs text-blue-700">
+                            {
+                              NOTIFICATION_KEYWORDS[
+                                key as keyof typeof NOTIFICATION_KEYWORDS
+                              ].title
+                            }
+                          </Text>
+                        </View>
+                      ))}
+                    </View>
+                  </View>
+                )}
+              </View>
+            </View>
+          </View>
+        )
+
+      default:
+        return null
+    }
+  }
+
+  const canProceed = () => {
+    if (currentPage === 1) return selectedCollege !== null
+    if (currentPage === 2) return selectedDepartment !== null
+    return true
+  }
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <View className="flex-1">
+        {/* 헤더 - 뒤로가기/건너뛰기 버튼 */}
+        <View className="flex-row items-center justify-between px-6">
+          {currentPage > 0 ? (
+            <TouchableOpacity onPress={handleBack} className="p-2">
+              <Ionicons name="arrow-back" size={24} color="#6B7280" />
+            </TouchableOpacity>
+          ) : (
+            <View className="w-10" />
+          )}
+        </View>
+
+        {/* 콘텐츠 영역 */}
+        {renderPage()}
+
+        {/* 페이지 인디케이터 */}
+        <View className="mb-6 flex-row justify-center">
+          {Array.from({ length: TOTAL_PAGES }).map((_, index) => (
+            <View
+              key={index}
+              className={`mx-1 h-2 rounded-full ${
+                index === currentPage ? 'w-8 bg-[#093a87]' : 'w-2 bg-gray-300'
+              }`}
+            />
+          ))}
+        </View>
+
+        {/* 다음/시작하기 버튼 */}
+        <View className="px-6 pb-8">
+          <TouchableOpacity
+            onPress={handleNext}
+            disabled={!canProceed()}
+            className={`rounded-xl py-4 ${
+              canProceed() ? 'bg-[#093a87]' : 'bg-gray-300'
+            }`}
+          >
+            <Text className="text-center text-lg font-semibold text-white">
+              {currentPage === TOTAL_PAGES - 1 ? '시작하기' : '다음'}
+            </Text>
+          </TouchableOpacity>
+
+          {!canProceed() && currentPage > 0 && (
+            <Text className="mt-2 text-center text-sm text-gray-500">
+              위에서 선택해주세요
+            </Text>
+          )}
+        </View>
+      </View>
+    </SafeAreaView>
+  )
+}

--- a/src/app/onboarding/index.tsx
+++ b/src/app/onboarding/index.tsx
@@ -204,7 +204,7 @@ export default function OnboardingScreen() {
           <View className="flex-1 px-6">
             <View className="mb-6 mt-4">
               <Text className="mb-2 text-center text-3xl font-bold text-gray-900">
-                어떤 주제의 공지를{'\n'}자주 보고 싶으신가요?
+                어떤 주제의 알림을{'\n'}받아 보고 싶으신가요?
               </Text>
               <Text className="text-center text-base text-gray-600">
                 선택한 주제의 새 공지를 먼저 알려드릴게요

--- a/src/components/layout/HomeDrawer/HomeDrawer.tsx
+++ b/src/components/layout/HomeDrawer/HomeDrawer.tsx
@@ -1,12 +1,7 @@
 import React, { useCallback, useMemo, useRef } from 'react'
 
 import { AntDesign, MaterialCommunityIcons } from '@expo/vector-icons'
-import {
-  BottomSheetBackdrop,
-  BottomSheetBackdropProps,
-  BottomSheetModal,
-  BottomSheetView,
-} from '@gorhom/bottom-sheet'
+import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet'
 import {
   DrawerContentComponentProps,
   DrawerContentScrollView,

--- a/src/components/layout/NotificationSettingHeader/NotificationSettingHeader.tsx
+++ b/src/components/layout/NotificationSettingHeader/NotificationSettingHeader.tsx
@@ -23,7 +23,7 @@ export default function NotificationSettingHeader() {
           <TouchableOpacity onPress={() => router.back()}>
             <Ionicons name="arrow-back" size={24} color="black" />
           </TouchableOpacity>
-          <Text className="text-2xl font-bold">알림 설정</Text>
+          <Text className="text-2xl font-semibold">알림 설정</Text>
         </View>
       </View>
     </View>

--- a/src/components/notification/NotificationContent/NotificationContent.tsx
+++ b/src/components/notification/NotificationContent/NotificationContent.tsx
@@ -8,7 +8,7 @@ export const NotificationContent = () => {
   const [selectedTab, setSelectedTab] = useState<'all' | 'unread'>('all')
 
   return (
-    <View className="flex-1">
+    <View className="flex-1 bg-gray-50">
       <View className="mb-4 flex-row items-center justify-center bg-gray-100 py-1">
         <TouchableOpacity
           className={`px-20 py-2 ${

--- a/src/components/ui/TagList/TagList.tsx
+++ b/src/components/ui/TagList/TagList.tsx
@@ -1,0 +1,73 @@
+import { Ionicons } from '@expo/vector-icons'
+import { View, Text, TouchableOpacity } from 'react-native'
+
+interface TagItem {
+  id: string
+  title: string
+  color?: string
+}
+
+interface TagListProps {
+  items: TagItem[]
+  onRemove: (id: string) => void
+  onAdd?: () => void
+  emptyText: string
+  addButtonText?: string
+  showAddButton?: boolean
+}
+
+export function TagList({
+  items,
+  onRemove,
+  onAdd,
+  emptyText,
+  addButtonText = '추가',
+  showAddButton = true,
+}: TagListProps) {
+  return (
+    <View className="gap-2">
+      {/* 태그 목록 */}
+      <View className="flex flex-row flex-wrap gap-2">
+        {items.length > 0 ? (
+          items.map((item) => (
+            <View
+              key={item.id}
+              className="flex flex-row items-center justify-center gap-1 rounded-full bg-blue-100 px-4 py-2 text-sm"
+            >
+              <TouchableOpacity>
+                <Text className="text-sm text-blue-700">{item.title}</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity onPress={() => onRemove(item.id)}>
+                <Ionicons name="close-outline" size={16} color="#3B82F6" />
+              </TouchableOpacity>
+            </View>
+          ))
+        ) : (
+          <View className="flex flex-row items-center justify-center gap-1 rounded-full bg-gray-100 px-4 py-2 text-sm">
+            <TouchableOpacity>
+              <Text className="text-sm text-gray-500">{emptyText}</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* 추가 버튼 */}
+      {showAddButton && onAdd && (
+        <View>
+          <TouchableOpacity
+            className="flex-row items-center justify-center gap-2 rounded-lg border border-gray-200 bg-white p-2"
+            onPress={onAdd}
+          >
+            <Ionicons name="add" size={20} color="black" />
+            <Text>
+              {items.length > 0
+                ? `${addButtonText} 수정`
+                : `${addButtonText} 추가`}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  )
+}

--- a/src/components/util/UtilContent/UtilContent.tsx
+++ b/src/components/util/UtilContent/UtilContent.tsx
@@ -58,7 +58,7 @@ export const UtilContent = () => {
 
   return (
     <ScrollView>
-      <View className="gap-6 px-4 py-4">
+      <View className="gap-6 bg-gray-50 px-4 py-4">
         {/* 빠른 바로가기 */}
         <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
           <Text className="mb-5 text-lg font-semibold">빠른 바로가기</Text>

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -1,0 +1,86 @@
+import { useMemo, useCallback } from 'react'
+
+import {
+  NOTIFICATION_KEYWORDS,
+  type SelectedKeywords,
+} from '@/constants/keyword'
+import { useNotificationStore } from '@/store/notificationStore'
+
+/**
+ * 알림 설정 관련 비즈니스 로직을 관리하는 커스텀 훅
+ */
+export function useNotificationSettings() {
+  const {
+    selectedKeywords: selectedKeywordsArray,
+    selectedDepartment,
+    notificationEnabled,
+    toggleKeyword,
+    setSelectedKeywords: setSelectedKeywordsArray,
+    setSelectedDepartment,
+    setNotificationEnabled,
+  } = useNotificationStore()
+
+  // string[] 형태를 SelectedKeywords 객체로 변환
+  const selectedKeywords: SelectedKeywords = useMemo(() => {
+    return selectedKeywordsArray.reduce((acc, key) => {
+      acc[key as keyof typeof NOTIFICATION_KEYWORDS] = true
+      return acc
+    }, {} as SelectedKeywords)
+  }, [selectedKeywordsArray])
+
+  // 선택된 학과를 배열로 변환 (기존 인터페이스 호환)
+  const selectedDepartments = useMemo(() => {
+    return selectedDepartment ? [selectedDepartment] : []
+  }, [selectedDepartment])
+
+  // 키워드 업데이트 핸들러 (KeywordBottomSheet에서 호출)
+  const handleKeywordUpdate = useCallback(
+    (newSelectedKeywords: SelectedKeywords) => {
+      // SelectedKeywords 객체에서 선택된 키워드들만 추출하여 배열로 변환
+      const keywordsArray = Object.keys(newSelectedKeywords).filter(
+        (key) => newSelectedKeywords[key as keyof typeof NOTIFICATION_KEYWORDS]
+      )
+      // 전역 상태 업데이트
+      setSelectedKeywordsArray(keywordsArray)
+    },
+    [setSelectedKeywordsArray]
+  )
+
+  // 학과 업데이트 핸들러 (DepatmentBottomSheet에서 호출)
+  const handleDepartmentUpdate = useCallback(
+    (newSelectedDepartments: string[]) => {
+      // 첫 번째 학과만 저장 (단일 선택)
+      setSelectedDepartment(newSelectedDepartments[0] || null)
+    },
+    [setSelectedDepartment]
+  )
+
+  // 키워드 제거 핸들러
+  const handleKeywordRemove = useCallback(
+    (keywordKey: string) => {
+      toggleKeyword(keywordKey)
+    },
+    [toggleKeyword]
+  )
+
+  // 학과 제거 핸들러
+  const handleDepartmentRemove = useCallback(() => {
+    setSelectedDepartment(null)
+  }, [setSelectedDepartment])
+
+  return {
+    // 상태
+    selectedKeywords,
+    selectedKeywordsArray,
+    selectedDepartment,
+    selectedDepartments,
+    notificationEnabled,
+
+    // 액션
+    setNotificationEnabled,
+    handleKeywordUpdate,
+    handleDepartmentUpdate,
+    handleKeywordRemove,
+    handleDepartmentRemove,
+  }
+}

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useRouter, useSegments } from 'expo-router'
+
+// AsyncStorage 키
+const ONBOARDING_KEY = 'hasSeenOnboarding'
+
+export function useOnboarding() {
+  const [isOnboardingComplete, setIsOnboardingComplete] = useState<
+    boolean | null
+  >(null)
+  const router = useRouter()
+  const segments = useSegments()
+
+  // 온보딩 완료 여부 체크
+  useEffect(() => {
+    const checkOnboarding = async () => {
+      try {
+        const value = await AsyncStorage.getItem(ONBOARDING_KEY)
+        setIsOnboardingComplete(value === 'true')
+      } catch (error) {
+        console.error('온보딩 상태 확인 실패:', error)
+        setIsOnboardingComplete(false)
+      }
+    }
+
+    checkOnboarding()
+  }, [])
+
+  // 온보딩 완료 여부에 따라 라우팅
+  useEffect(() => {
+    const handleRouting = async () => {
+      if (isOnboardingComplete === null) return // 로딩 중
+
+      const inOnboarding = segments[0] === 'onboarding'
+      const inTabs = segments[0] === '(tabs)'
+
+      // (tabs)로 이동하려는 경우 AsyncStorage를 다시 체크
+      if (inTabs && !isOnboardingComplete) {
+        const value = await AsyncStorage.getItem(ONBOARDING_KEY)
+        if (value === 'true') {
+          setIsOnboardingComplete(true)
+          return
+        }
+      }
+
+      if (!isOnboardingComplete && !inOnboarding) {
+        // 온보딩 미완료 상태이고 온보딩 화면이 아니면 온보딩으로 이동
+        router.replace('/onboarding')
+      } else if (isOnboardingComplete && inOnboarding) {
+        // 온보딩 완료 상태인데 온보딩 화면에 있으면 메인으로 이동
+        router.replace('/(tabs)')
+      }
+    }
+
+    handleRouting()
+  }, [isOnboardingComplete, segments, router])
+
+  return { isOnboardingComplete }
+}

--- a/src/store/notificationStore.ts
+++ b/src/store/notificationStore.ts
@@ -1,0 +1,79 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+import { NotificationSettings } from '@/types/notification.type'
+
+// 스토어에 보관할 상태와 함수의 타입을 정의합니다.
+interface NotificationStore extends NotificationSettings {
+  // 알림 설정 전체 업데이트
+  setNotificationSettings: (settings: NotificationSettings) => void
+  // 단과대학 선택
+  setSelectedCollege: (college: string | null) => void
+  // 학과 선택
+  setSelectedDepartment: (department: string | null) => void
+  // 키워드 토글
+  toggleKeyword: (keyword: string) => void
+  // 키워드 배열 설정
+  setSelectedKeywords: (keywords: string[]) => void
+  // 알림 활성화 토글
+  setNotificationEnabled: (enabled: boolean) => void
+  // 모든 설정 초기화
+  resetSettings: () => void
+}
+
+// 초기 상태
+const initialState: NotificationSettings = {
+  selectedCollege: null,
+  selectedDepartment: null,
+  selectedKeywords: [],
+  notificationEnabled: true,
+}
+
+// Zustand 스토어 생성 (persist 미들웨어로 AsyncStorage에 자동 저장)
+export const useNotificationStore = create<NotificationStore>()(
+  persist(
+    (set) => ({
+      ...initialState,
+
+      // 알림 설정 전체 업데이트
+      setNotificationSettings: (settings) => set(settings),
+
+      // 단과대학 선택
+      setSelectedCollege: (college) =>
+        set({ selectedCollege: college, selectedDepartment: null }),
+
+      // 학과 선택
+      setSelectedDepartment: (department) =>
+        set({ selectedDepartment: department }),
+
+      // 키워드 토글 (있으면 제거, 없으면 추가)
+      toggleKeyword: (keyword) =>
+        set((state) => ({
+          selectedKeywords: state.selectedKeywords.includes(keyword)
+            ? state.selectedKeywords.filter((k) => k !== keyword)
+            : [...state.selectedKeywords, keyword],
+        })),
+
+      // 키워드 배열 설정
+      setSelectedKeywords: (keywords) => set({ selectedKeywords: keywords }),
+
+      // 알림 활성화 토글
+      setNotificationEnabled: (enabled) =>
+        set({ notificationEnabled: enabled }),
+
+      // 모든 설정 초기화
+      resetSettings: () => set(initialState),
+    }),
+    {
+      name: 'notification-storage', // AsyncStorage 키
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        selectedCollege: state.selectedCollege,
+        selectedDepartment: state.selectedDepartment,
+        selectedKeywords: state.selectedKeywords,
+        notificationEnabled: state.notificationEnabled,
+      }),
+    }
+  )
+)

--- a/src/types/notification.type.ts
+++ b/src/types/notification.type.ts
@@ -1,0 +1,15 @@
+/**
+ * 알림 설정 관련 타입 정의
+ */
+
+// 알림 설정 정보
+export interface NotificationSettings {
+  // 선택한 단과대학 키
+  selectedCollege: string | null
+  // 선택한 학과 이름
+  selectedDepartment: string | null
+  // 선택한 키워드 목록
+  selectedKeywords: string[]
+  // 푸시 알림 활성화 여부
+  notificationEnabled: boolean
+}


### PR DESCRIPTION
## 📝설명
해당 PR은 유저가 앱에 첫 진입을 했을 때 스플래쉬 스크린 이후 렌더링되는 온보딩 페이지 개발을 목표로 합니다.
온보딩에서 사용자의 학과, 관심 키워드, 푸시 알림 동의 설정을 한 후 '/' 페이지로 리다이렉션 시킵니다.
또한 해당 온보딩 정보는 전역 상태로 관리되어 알림 설정 페이지에 동기화 합니다. 

### 📍개발 범위
<img width="716" height="670" alt="1" src="https://github.com/user-attachments/assets/a0793f61-724c-4923-b59c-905746f780b3" />
<img width="723" height="694" alt="2" src="https://github.com/user-attachments/assets/7f8c74e1-b08c-474d-b57a-6995da8a2c18" />
<img width="716" height="660" alt="3" src="https://github.com/user-attachments/assets/20bc1870-9ab6-421c-bcef-9eb82bbbafd9" />
