### PR TITLE
feat: notification-list

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       "favicon": "./src/assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      "expo-web-browser"
     ],
     "experiments": {
       "typedRoutes": true

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "expo-router": "~6.0.7",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
-    "expo-web-browser": "~15.0.7",
+    "expo-web-browser": "~15.0.8",
     "firebase": "^12.3.0",
     "nativewind": "^4.2.1",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ~3.0.8
         version: 3.0.8(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-web-browser:
-        specifier: ~15.0.7
-        version: 15.0.7(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
+        specifier: ~15.0.8
+        version: 15.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
       firebase:
         specifier: ^12.3.0
         version: 12.3.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)))
@@ -2805,8 +2805,8 @@ packages:
       react: '*'
       react-native: '*'
 
-  expo-web-browser@15.0.7:
-    resolution: {integrity: sha512-eXnfO3FQ2WthTA8uEPNJ7SDRfPaLIU/P2k082HGEYIHAFZMwh2o9Wo+SDVytO3E95TAv1qwhggUjOrczYzxteQ==}
+  expo-web-browser@15.0.8:
+    resolution: {integrity: sha512-gn+Y2ABQr6/EvFN/XSjTuzwsSPLU1vNVVV0wNe4xXkcSnYGdHxt9kHxs9uLfoCyPByoaGF4VxzAhHIMI7yDcSg==}
     peerDependencies:
       expo: '*'
       react-native: '*'
@@ -8603,7 +8603,7 @@ snapshots:
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
       react-native-is-edge-to-edge: 1.2.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
 
-  expo-web-browser@15.0.7(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)):
+  expo-web-browser@15.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)):
     dependencies:
       expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)

--- a/src/components/notice/NoticeContent/NoticeContent.tsx
+++ b/src/components/notice/NoticeContent/NoticeContent.tsx
@@ -2,7 +2,8 @@ import { useRef, useMemo } from 'react'
 
 import { Ionicons } from '@expo/vector-icons'
 import * as Haptics from 'expo-haptics'
-import { View, Text } from 'react-native'
+import * as WebBrowser from 'expo-web-browser'
+import { View, Text, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
@@ -55,6 +56,13 @@ export const NoticeContent = ({ item }: NoticeContentProps) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
   }
 
+  // 공지 링크 열기
+  const handleOpenLink = () => {
+    if (item.link) {
+      WebBrowser.openBrowserAsync(item.link)
+    }
+  }
+
   return (
     <Swipeable
       ref={swipeableRef}
@@ -71,7 +79,11 @@ export const NoticeContent = ({ item }: NoticeContentProps) => {
       overshootLeft={false}
       overshootRight={false}
     >
-      <View className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t border-gray-200 bg-white p-5 pr-4">
+      <TouchableOpacity
+        className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t border-gray-200 bg-white p-5 pr-4"
+        onPress={handleOpenLink}
+        activeOpacity={0.7}
+      >
         <View className="flex-1 justify-between">
           <View className="flex-row items-start justify-between">
             <Text
@@ -108,7 +120,7 @@ export const NoticeContent = ({ item }: NoticeContentProps) => {
             </Text>
           </View>
         </View>
-      </View>
+      </TouchableOpacity>
     </Swipeable>
   )
 }

--- a/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
+++ b/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
@@ -1,88 +1,170 @@
-import React from 'react'
+import { useRef } from 'react'
 
+import * as Haptics from 'expo-haptics'
 import { View, Text, TouchableOpacity } from 'react-native'
+import Swipeable, {
+  SwipeableMethods,
+} from 'react-native-gesture-handler/ReanimatedSwipeable'
 
-interface NotificationItem {
-  id: string
-  title: string
-  department: string
-  tags: string[]
-  date: string
-  timeAgo: string
-  isRead: boolean
-}
+import RightSwipeActions from '@/components/ui/RightSwipeActions/RightSwipeActions'
+import { PushNotificationItem } from '@/types/notification.type'
+import { getFormattedDate } from '@/utils/dateUtils'
+import { getDepartmentStyles } from '@/utils/departmentStyles'
 
 interface NotificaitonItemProps {
-  filter: 'all' | 'unread'
+  items: Array<
+    Pick<
+      PushNotificationItem,
+      'id' | 'title' | 'department' | 'category' | 'read' | 'createdAtMs'
+    > & { tags?: string[] }
+  >
+  onPress?: (item: {
+    id: string
+    noticeLink?: string
+    noticeId?: string
+  }) => void
+  onDelete?: (item: { id: string; title: string }) => void
 }
 
-export function NotificaitonItem({ filter }: NotificaitonItemProps) {
-  // 임시 데이터
-  const notifications: NotificationItem[] = [
-    {
-      id: '1',
-      title: '2025학년도 2학기 자격 시험 결과 발표 예정일 안내',
-      department: '컴퓨터공학과',
-      tags: ['#학사'],
-      date: '2025.10.06',
-      timeAgo: '5분전',
-      isRead: false,
-    },
-    {
-      id: '2',
-      title: '다른 공지사항입니다',
-      department: '컴퓨터공학과',
-      tags: ['#공지'],
-      date: '2025.10.06',
-      timeAgo: '10분전',
-      isRead: true,
-    },
-  ]
-
-  // 필터링 로직
-  const filteredNotifications =
-    filter === 'unread'
-      ? notifications.filter((item) => !item.isRead)
-      : notifications
-
+export function NotificaitonItem({
+  items,
+  onPress,
+  onDelete,
+}: NotificaitonItemProps) {
   return (
     <>
-      {filteredNotifications.map((item) => (
-        <TouchableOpacity
+      {items.map((item) => (
+        <NotificationItemContent
           key={item.id}
-          className={`mx-4 mb-3 min-h-[100px] rounded-lg border ${
-            item.isRead
-              ? 'border-gray-100 bg-white'
-              : 'border-blue-100 bg-blue-50'
-          } p-4`}
-        >
-          <View className="flex-row justify-between">
-            <View className="flex-1">
-              <Text
-                className="text-base font-semibold text-gray-800"
-                numberOfLines={2}
-              >
-                {item.title}
-              </Text>
-            </View>
-            {!item.isRead && (
+          item={item}
+          onPress={onPress}
+          onDelete={onDelete}
+        />
+      ))}
+    </>
+  )
+}
+
+interface NotificationItemContentProps {
+  item: Pick<
+    PushNotificationItem,
+    'id' | 'title' | 'department' | 'category' | 'read' | 'createdAtMs'
+  > & { tags?: string[] }
+  onPress?: (item: {
+    id: string
+    noticeLink?: string
+    noticeId?: string
+  }) => void
+  onDelete?: (item: { id: string; title: string }) => void
+}
+
+function NotificationItemContent({
+  item,
+  onPress,
+  onDelete,
+}: NotificationItemContentProps) {
+  // 스와이프 참조
+  const swipeableRef = useRef<SwipeableMethods>(null)
+
+  // 부서 스타일 가져오기
+  const departmentStyle = item.department
+    ? getDepartmentStyles(item.department)
+    : null
+
+  // 삭제 핸들러
+  const handleDelete = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium)
+    onDelete?.({ id: item.id, title: item.title })
+    swipeableRef.current?.close()
+  }
+
+  // 스와이프 활성화 시 햅틱 피드백
+  const handleSwipeableWillOpen = () => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
+  }
+
+  return (
+    <Swipeable
+      ref={swipeableRef}
+      renderRightActions={() => (
+        <RightSwipeActions
+          onPress={handleDelete}
+          isScraped={false}
+          isDeleteOnly={true} // 알림은 삭제만 가능
+        />
+      )}
+      onSwipeableWillOpen={handleSwipeableWillOpen}
+      containerStyle={{
+        marginBottom: 10,
+      }}
+      overshootLeft={false}
+      overshootRight={false}
+    >
+      <TouchableOpacity
+        className={`ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t ${
+          item.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'
+        } p-5 pr-4`}
+        onPress={() => onPress?.(item)}
+        activeOpacity={0.7}
+      >
+        <View className="flex-1 justify-between">
+          <View className="flex-row items-start justify-between">
+            <Text
+              className={`flex-1 pr-2 text-base font-medium leading-snug ${
+                item.read ? 'text-gray-900' : 'text-gray-800'
+              }`}
+              numberOfLines={2}
+            >
+              {item.title}
+            </Text>
+            {!item.read && (
               <View className="h-2 w-2 rounded-full bg-blue-500" />
             )}
           </View>
-          <View className="mt-2">
-            <View className="flex-row items-center justify-between">
-              <View className="flex-row items-center gap-2">
-                <Text className="ml-[-4px] rounded-full bg-slate-100 px-2 py-1 text-xs font-bold text-gray-700">
-                  {item.department}
-                </Text>
-                <Text className="text-xs text-gray-700">{item.tags}</Text>
-              </View>
-              <Text className="text-xs text-gray-500">{item.date}</Text>
+
+          <View className="flex-row items-center justify-between gap-3">
+            <View className="flex-1 flex-row items-center gap-2">
+              {item.department && departmentStyle && (
+                <View
+                  className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}
+                >
+                  <Text
+                    className={`text-xs font-medium ${departmentStyle.text}`}
+                  >
+                    {item.department}
+                  </Text>
+                </View>
+              )}
+
+              {item.category && (
+                <View className="rounded-md bg-gray-100 px-2 py-1">
+                  <Text className="text-xs font-medium text-gray-600">
+                    #{item.category}
+                  </Text>
+                </View>
+              )}
+
+              {item.tags && item.tags.length > 0 && (
+                <View className="flex-1 flex-row flex-wrap gap-1.5">
+                  {item.tags.slice(0, 2).map((tag) => (
+                    <View
+                      key={tag}
+                      className="rounded-md bg-gray-100 px-2 py-1"
+                    >
+                      <Text className="text-xs font-medium text-gray-600">
+                        #{tag}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              )}
             </View>
-            <Text className="mt-2 text-xs text-gray-500">{item.timeAgo}</Text>
+            <Text className="text-xs font-normal text-gray-500">
+              {getFormattedDate(item.createdAtMs)}
+            </Text>
           </View>
-        </TouchableOpacity>
-      ))}
-    </>
+        </View>
+      </TouchableOpacity>
+    </Swipeable>
   )
 }

--- a/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
+++ b/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react'
 
 import * as Haptics from 'expo-haptics'
+import * as WebBrowser from 'expo-web-browser'
 import { View, Text, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
@@ -48,7 +49,14 @@ export function NotificaitonItem({
 interface NotificationItemContentProps {
   item: Pick<
     PushNotificationItem,
-    'id' | 'title' | 'department' | 'category' | 'read' | 'createdAtMs'
+    | 'id'
+    | 'title'
+    | 'department'
+    | 'category'
+    | 'read'
+    | 'createdAtMs'
+    | 'noticeLink'
+    | 'noticeId'
   > & { tags?: string[] }
   onPress?: (item: {
     id: string
@@ -83,6 +91,18 @@ function NotificationItemContent({
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
   }
 
+  // 알림 탭: 브라우저 열고(있으면) 상위 onPress 호출
+  const handlePress = () => {
+    if (item.noticeLink) {
+      WebBrowser.openBrowserAsync(item.noticeLink)
+    }
+    onPress?.({
+      id: item.id,
+      noticeLink: item.noticeLink,
+      noticeId: item.noticeId,
+    })
+  }
+
   return (
     <Swipeable
       ref={swipeableRef}
@@ -104,7 +124,7 @@ function NotificationItemContent({
         className={`ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t ${
           item.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'
         } p-5 pr-4`}
-        onPress={() => onPress?.(item)}
+        onPress={handlePress}
         activeOpacity={0.7}
       >
         <View className="flex-1 justify-between">

--- a/src/components/notification/NotificationContent/NotificationContent.tsx
+++ b/src/components/notification/NotificationContent/NotificationContent.tsx
@@ -1,11 +1,48 @@
-import { useState } from 'react'
+import { useMemo, useState, useCallback } from 'react'
 
-import { View, Text, TouchableOpacity } from 'react-native'
+import * as Linking from 'expo-linking'
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native'
+
+import useFetchNotification from '@/hooks/useFetchNotification'
 
 import { NotificaitonItem } from '../NotificaitonItem/NotificaitonItem'
 
 export const NotificationContent = () => {
   const [selectedTab, setSelectedTab] = useState<'all' | 'unread'>('all')
+  const { items, loading, error, markAsRead, deleteNotification } =
+    useFetchNotification({
+      pageSize: 100,
+      realtime: true,
+    })
+
+  const filtered = useMemo(
+    () => (selectedTab === 'unread' ? items.filter((x) => !x.read) : items),
+    [items, selectedTab]
+  )
+
+  const isEmptyUnread = selectedTab === 'unread' && filtered.length === 0
+  const isEmptyAll = selectedTab === 'all' && filtered.length === 0
+
+  const handlePress = useCallback(
+    async (item: { id: string; noticeLink?: string; noticeId?: string }) => {
+      if (item.noticeLink) {
+        Linking.openURL(item.noticeLink)
+      }
+      await markAsRead(item.id)
+    },
+    [markAsRead]
+  )
+
+  const handleDelete = useCallback(
+    async (item: { id: string; title: string }) => {
+      try {
+        await deleteNotification(item.id)
+      } catch (error) {
+        console.error('알림 삭제 실패:', error)
+      }
+    },
+    [deleteNotification]
+  )
 
   return (
     <View className="flex-1 bg-gray-50">
@@ -27,7 +64,41 @@ export const NotificationContent = () => {
           <Text className="font-semibold">안 읽음</Text>
         </TouchableOpacity>
       </View>
-      <NotificaitonItem filter={selectedTab} />
+      {loading ? (
+        <View className="flex-1 items-center justify-center bg-white">
+          <ActivityIndicator size="large" color="#3B82F6" />
+        </View>
+      ) : error ? (
+        <Text className="px-4 py-2 text-red-500">{error}</Text>
+      ) : (
+        <>
+          {isEmptyUnread ? (
+            <View className="mx-4 items-center justify-center rounded-lg border border-gray-100 bg-white p-6">
+              <Text className="text-base font-semibold text-gray-800">
+                아직 안 읽은 알림이 없어요
+              </Text>
+              <Text className="mt-1 text-sm text-gray-500">
+                새로운 알림이 오면 여기에서 확인할 수 있어요.
+              </Text>
+            </View>
+          ) : isEmptyAll ? (
+            <View className="mx-4 items-center justify-center rounded-lg border border-gray-100 bg-white p-6">
+              <Text className="text-base font-semibold text-gray-800">
+                아직 알림이 없어요
+              </Text>
+              <Text className="mt-1 text-sm text-gray-500">
+                관심 주제 알림을 설정하고 새로운 소식을 받아보세요.
+              </Text>
+            </View>
+          ) : (
+            <NotificaitonItem
+              items={filtered}
+              onPress={handlePress}
+              onDelete={handleDelete}
+            />
+          )}
+        </>
+      )}
     </View>
   )
 }

--- a/src/components/scrap/ScrapItem/ScrapItem.tsx
+++ b/src/components/scrap/ScrapItem/ScrapItem.tsx
@@ -1,7 +1,8 @@
 import { useRef } from 'react'
 
 import * as Haptics from 'expo-haptics'
-import { Text, View } from 'react-native'
+import * as WebBrowser from 'expo-web-browser'
+import { Text, View, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
@@ -29,6 +30,13 @@ export const ScrapItem = ({ scrap }: { scrap: Scrap }) => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light)
   }
 
+  // 링크 열기
+  const handleOpenLink = () => {
+    if (scrap.notice.link) {
+      WebBrowser.openBrowserAsync(scrap.notice.link)
+    }
+  }
+
   return (
     <Swipeable
       ref={swipeableRef}
@@ -42,7 +50,11 @@ export const ScrapItem = ({ scrap }: { scrap: Scrap }) => {
       overshootLeft={false}
       overshootRight={false}
     >
-      <View className="min-h-[105px] rounded-lg border-l-4 border-deu-light-blue bg-white p-6">
+      <TouchableOpacity
+        className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-l-4 border-deu-light-blue bg-white p-5 pr-4"
+        onPress={handleOpenLink}
+        activeOpacity={0.7}
+      >
         <View className="flex-1 justify-between">
           <View className="flex-row items-start justify-between">
             <Text
@@ -77,7 +89,7 @@ export const ScrapItem = ({ scrap }: { scrap: Scrap }) => {
             </Text>
           </View>
         </View>
-      </View>
+      </TouchableOpacity>
     </Swipeable>
   )
 }

--- a/src/components/scrap/ScrapList/ScrapList.tsx
+++ b/src/components/scrap/ScrapList/ScrapList.tsx
@@ -26,7 +26,7 @@ export const ScrapList: React.FC<ScrapListProps> = ({ scraps }) => {
       data={scraps}
       keyExtractor={(item) => item.notice.content_hash}
       renderItem={({ item }) => <ScrapItem scrap={item} />}
-      contentContainerStyle={{ paddingHorizontal: 16, paddingTop: 20 }}
+      contentContainerStyle={{ paddingTop: 20 }}
       showsVerticalScrollIndicator={true}
       style={{ flex: 1 }}
     />

--- a/src/components/scrap/ScrapList/ScrapList.tsx
+++ b/src/components/scrap/ScrapList/ScrapList.tsx
@@ -10,9 +10,12 @@ import { ScrapItem } from '../ScrapItem/ScrapItem'
 export const ScrapList: React.FC<ScrapListProps> = ({ scraps }) => {
   if (scraps.length === 0) {
     return (
-      <View className="items-center justify-center py-20">
-        <Text className="text-base text-gray-500">
-          스크랩한 공지가 없습니다
+      <View className="mx-4 mt-4 items-center justify-center rounded-lg border border-gray-100 bg-white p-6">
+        <Text className="text-base font-semibold text-gray-800">
+          아직 저장된 스크랩이 없어요
+        </Text>
+        <Text className="mt-1 text-sm text-gray-500">
+          공지사항을 스크랩하면 여기에서 확인할 수 있어요.
         </Text>
       </View>
     )

--- a/src/components/ui/RightSwipeActions/RightSwipeActions.tsx
+++ b/src/components/ui/RightSwipeActions/RightSwipeActions.tsx
@@ -5,25 +5,29 @@ import { Text, TouchableOpacity } from 'react-native'
 export default function RightSwipeActions({
   onPress,
   isScraped,
+  isDeleteOnly = false,
 }: {
   onPress: () => void
   isScraped: boolean
+  isDeleteOnly?: boolean
 }) {
+  const isDeleteAction = isDeleteOnly || isScraped
+
   return (
     <TouchableOpacity
       onPress={onPress}
       className={`mr-4 min-h-[105px] w-20 items-center justify-center rounded-r-lg ${
-        isScraped ? 'bg-red-500' : 'bg-blue-500'
+        isDeleteAction ? 'bg-red-500' : 'bg-blue-500'
       }`}
       activeOpacity={0.7}
     >
       <Ionicons
-        name={isScraped ? 'trash-outline' : 'bookmark'}
+        name={isDeleteAction ? 'trash-outline' : 'bookmark'}
         size={24}
         color="white"
       />
       <Text className="mt-1 text-sm font-semibold text-white">
-        {isScraped ? '삭제' : '스크랩'}
+        {isDeleteAction ? '삭제' : '스크랩'}
       </Text>
     </TouchableOpacity>
   )

--- a/src/hooks/useFetchNotification.ts
+++ b/src/hooks/useFetchNotification.ts
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+
+import {
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  limit,
+  onSnapshot,
+  query,
+  updateDoc,
+  Unsubscribe,
+} from 'firebase/firestore'
+
+import { db } from '@/config/firebaseConfig'
+import { usePushNotifications } from '@/hooks/usePushNotifications'
+import {
+  PushNotificationDoc,
+  PushNotificationItem,
+} from '@/types/notification.type'
+
+type UseFetchNotificationOptions = {
+  pageSize?: number
+  realtime?: boolean
+}
+
+function toItem(docData: PushNotificationDoc): PushNotificationItem {
+  return {
+    id: docData.id,
+    title: docData.title,
+    body: docData.body ?? '',
+    // 링크/식별자 키 정규화
+    noticeLink: docData.noticeLink || docData.link,
+    noticeId: docData.noticeId || docData.content_hash || docData.target_id,
+    category: docData.category,
+    department: docData.department,
+    read: docData.read ?? docData.is_read ?? false,
+    // 우선순위: createdAt > sent_at > saved_at > published_at
+    createdAtMs:
+      (docData.createdAt?.toMillis?.() as number | undefined) ??
+      (docData.sent_at?.toMillis?.() as number | undefined) ??
+      (docData.saved_at?.toMillis?.() as number | undefined) ??
+      (docData.published_at?.toMillis?.() as number | undefined) ??
+      Date.now(),
+  }
+}
+
+export function useFetchNotification(
+  options: UseFetchNotificationOptions = {}
+) {
+  const { getPushToken } = usePushNotifications()
+  const pageSize = options.pageSize ?? 50
+  const enableRealtime = options.realtime ?? true
+
+  const [loading, setLoading] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const [items, setItems] = useState<PushNotificationItem[]>([])
+
+  const tokenRef = useRef<string | null>(null)
+  const unsubRef = useRef<Unsubscribe | null>(null)
+
+  const fetchToken = useCallback(async (): Promise<string | null> => {
+    const token = await getPushToken()
+    tokenRef.current = token
+    return token
+  }, [getPushToken])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const token = tokenRef.current ?? (await fetchToken())
+      if (!token) {
+        setItems([])
+        setLoading(false)
+        return
+      }
+
+      const col = collection(db, 'device_tokens', token, 'notifications')
+      const q = query(col, limit(pageSize))
+
+      const snap = await getDocs(q)
+      const data: PushNotificationItem[] = snap.docs.map((d) =>
+        toItem({ id: d.id, ...(d.data() as Omit<PushNotificationDoc, 'id'>) })
+      )
+      // 최신순 정렬 (클라이언트 사이드)
+      const sorted = data.sort((a, b) => b.createdAtMs - a.createdAtMs)
+
+      setItems(sorted)
+
+      if (enableRealtime) {
+        unsubRef.current?.()
+        unsubRef.current = onSnapshot(q, (ss) => {
+          const next = ss.docs.map((d) =>
+            toItem({
+              id: d.id,
+              ...(d.data() as Omit<PushNotificationDoc, 'id'>),
+            })
+          )
+          const sortedRealtime = next.sort(
+            (a, b) => b.createdAtMs - a.createdAtMs
+          )
+          setItems(sortedRealtime)
+        })
+      }
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e)
+      setError(message || '알림을 불러오지 못했어요')
+    } finally {
+      setLoading(false)
+    }
+  }, [enableRealtime, fetchToken, pageSize])
+
+  useEffect(() => {
+    load()
+    return () => {
+      unsubRef.current?.()
+    }
+  }, [load])
+
+  const markAsRead = useCallback(
+    async (id: string) => {
+      if (!id) return
+      try {
+        const token = tokenRef.current ?? (await fetchToken())
+        if (!token) return
+
+        const ref = doc(db, 'device_tokens', token, 'notifications', id)
+
+        await updateDoc(ref, { read: true, is_read: true })
+        setItems((prev) =>
+          prev.map((x) => (x.id === id ? { ...x, read: true } : x))
+        )
+      } catch (e) {
+        console.error('[useFetchNotification] markAsRead error', e)
+      }
+    },
+    [fetchToken]
+  )
+
+  const markAllAsRead = useCallback(async () => {
+    try {
+      const token = tokenRef.current ?? (await fetchToken())
+      if (!token) return
+
+      const current = items.filter((x) => !x.read)
+
+      await Promise.all(
+        current.map((x) =>
+          updateDoc(doc(db, 'device_tokens', token, 'notifications', x.id), {
+            read: true,
+            is_read: true,
+          })
+        )
+      )
+      setItems((prev) => prev.map((x) => ({ ...x, read: true })))
+    } catch (e) {
+      console.error('[useFetchNotification] markAllAsRead error', e)
+    }
+  }, [items, fetchToken])
+
+  const deleteNotification = useCallback(
+    async (id: string) => {
+      if (!id) return
+      try {
+        const token = tokenRef.current ?? (await fetchToken())
+        if (!token) return
+
+        const ref = doc(db, 'device_tokens', token, 'notifications', id)
+        await deleteDoc(ref)
+
+        // 로컬 상태에서도 제거
+        setItems((prev) => prev.filter((x) => x.id !== id))
+      } catch (e) {
+        console.error('[useFetchNotification] deleteNotification error', e)
+        throw e // 에러를 다시 던져서 UI에서 처리할 수 있도록
+      }
+    },
+    [fetchToken]
+  )
+
+  const unreadCount = useMemo(
+    () => items.filter((x) => !x.read).length,
+    [items]
+  )
+
+  return {
+    items,
+    loading,
+    error,
+    unreadCount,
+    reload: load,
+    markAsRead,
+    markAllAsRead,
+    deleteNotification,
+  }
+}
+
+export default useFetchNotification

--- a/src/hooks/useFilteredAndSortedScraps.ts
+++ b/src/hooks/useFilteredAndSortedScraps.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 
 import { NOTIFICATION_KEYWORDS } from '@/constants/keyword'
 import { Scrap } from '@/store/scrapStore'
+import { getTimeMs } from '@/utils/dateUtils'
 
 type SortOption = 'latest' | 'oldest'
 
@@ -48,11 +49,11 @@ export const useFilteredAndSortedScraps = ({
     // 정렬
     if (sortBy === 'latest') {
       result.sort(
-        (a, b) => b.notice.saved_at.toMillis() - a.notice.saved_at.toMillis()
+        (a, b) => getTimeMs(b.notice.saved_at) - getTimeMs(a.notice.saved_at)
       )
     } else if (sortBy === 'oldest') {
       result.sort(
-        (a, b) => a.notice.saved_at.toMillis() - b.notice.saved_at.toMillis()
+        (a, b) => getTimeMs(a.notice.saved_at) - getTimeMs(b.notice.saved_at)
       )
     }
 

--- a/src/types/notification.type.ts
+++ b/src/types/notification.type.ts
@@ -13,3 +13,42 @@ export interface NotificationSettings {
   // 푸시 알림 활성화 여부
   notificationEnabled: boolean
 }
+
+// 푸시 알림 아이템
+export interface PushNotificationDoc {
+  id: string // 문서 id
+  token?: string // Expo 푸시 토큰 (없을 수 있음)
+  title: string
+  body?: string
+  // 링크/식별자 다양한 키 대응
+  noticeLink?: string
+  link?: string
+  noticeId?: string
+  content_hash?: string
+  target_id?: string
+  // 메타 정보
+  category?: string
+  department?: string
+  tags?: string[]
+  // 읽음 플래그 다양한 키 대응
+  read?: boolean
+  is_read?: boolean
+  // 시간 필드 다양한 키 대응
+  createdAt?: import('firebase/firestore').Timestamp
+  sent_at?: import('firebase/firestore').Timestamp
+  saved_at?: import('firebase/firestore').Timestamp
+  published_at?: import('firebase/firestore').Timestamp
+}
+
+// 앱에서 쓰기 편한 형태
+export interface PushNotificationItem {
+  id: string
+  title: string
+  body: string
+  noticeLink?: string
+  noticeId?: string
+  category?: string
+  department?: string
+  read: boolean
+  createdAtMs: number
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from 'firebase/firestore'
 
-// 파이어베이스 타임스탬프, 문자열, 숫자를 받아서 원하는 형식의 날짜 문자열을 반환합니다.
+// UI에 표시할 형식의 날짜 문자열을 반환합니다.
 export const getFormattedDate = (
   dateValue: Timestamp | string | number
 ): string => {
@@ -20,4 +20,29 @@ export const getFormattedDate = (
   }
 
   return ''
+}
+
+// 정렬/계산 다양한 형태의 날짜 값을 ms(number)로 변환합니다.
+export const getTimeMs = (value: unknown): number => {
+  if (!value) return 0
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const ms = new Date(value).getTime()
+    return Number.isFinite(ms) ? ms : 0
+  }
+  // 타입 가드들로 좁히기
+  type PersistedTimestamp = { seconds: number; nanoseconds?: number }
+  const hasToMillis = (v: unknown): v is { toMillis: () => number } =>
+    !!v && typeof (v as { toMillis?: unknown }).toMillis === 'function'
+  const isPersisted = (v: unknown): v is PersistedTimestamp =>
+    !!v && typeof (v as { seconds?: unknown }).seconds === 'number'
+
+  if (value instanceof Timestamp || hasToMillis(value)) {
+    return (value as Timestamp | { toMillis: () => number }).toMillis()
+  }
+  if (isPersisted(value)) {
+    const ns = typeof value.nanoseconds === 'number' ? value.nanoseconds : 0
+    return value.seconds * 1000 + Math.floor(ns / 1e6)
+  }
+  return 0
 }


### PR DESCRIPTION
## 📝설명
해당 PR에서는 #11  에서 테스트한 푸시 알림을 리스트로써 보여주며 스와이프를 통해 삭제하여 해당 유저가 받은 푸시 알림의 알림을 제거할 수 있는 기능을 개발했습니다.
또한 각 공지사항 게시글의 상세 페이지 이동을 위한 `expo-web-browser`를 사용하여 간단한 인앱 상세 웹사이트를 구현했습니다.

### 📍개발 범위
- <img width="727" height="731" alt="1" src="https://github.com/user-attachments/assets/dae1cbca-f32e-4009-a406-dd39da14a050" />
- <img width="728" height="735" alt="2" src="https://github.com/user-attachments/assets/879e24e8-34ad-4835-977f-c3d9aa08544f" />
- <img width="708" height="748" alt="3" src="https://github.com/user-attachments/assets/22479dc5-6e52-4233-b4ac-f903c3293c54" />
