### PR TITLE
feat: utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^5.90.2",
     "expo": "~54.0.9",
     "expo-checkbox": "~5.0.7",
+    "expo-clipboard": "^8.0.7",
     "expo-constants": "~18.0.9",
     "expo-device": "~8.0.9",
     "expo-font": "~14.0.8",
@@ -42,6 +43,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "^13.16.0",
     "react-native-worklets": "0.5.1",
     "tailwindcss": "^3.4.17",
     "zustand": "^5.0.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,10 +28,13 @@ importers:
         version: 5.90.2(react@19.1.0)
       expo:
         specifier: ~54.0.9
-        version: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+        version: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-checkbox:
         specifier: ~5.0.7
         version: 5.0.7(react-native-web@0.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo-clipboard:
+        specifier: ^8.0.7
+        version: 8.0.7(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-constants:
         specifier: ~18.0.9
         version: 18.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
@@ -98,6 +101,9 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react-native-webview:
+        specifier: ^13.16.0
+        version: 13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native-worklets:
         specifier: 0.5.1
         version: 0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
@@ -2702,6 +2708,13 @@ packages:
       react-native-web:
         optional: true
 
+  expo-clipboard@8.0.7:
+    resolution: {integrity: sha512-zvlfFV+wB2QQrQnHWlo0EKHAkdi2tycLtE+EXFUWTPZYkgu1XcH+aiKfd4ul7Z0SDF+1IuwoiW9AA9eO35aj3Q==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-constants@18.0.9:
     resolution: {integrity: sha512-sqoXHAOGDcr+M9NlXzj1tGoZyd3zxYDy215W6E0Z0n8fgBaqce9FAYQE2bu5X4G629AYig5go7U6sQz7Pjcm8A==}
     peerDependencies:
@@ -4390,6 +4403,12 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
+  react-native-webview@13.16.0:
+    resolution: {integrity: sha512-Nh13xKZWW35C0dbOskD7OX01nQQavOzHbCw9XoZmar4eXCo7AvrYJ0jlUfRVVIJzqINxHlpECYLdmAdFsl9xDA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
+
   react-native-worklets@0.5.1:
     resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
     peerDependencies:
@@ -5991,7 +6010,7 @@ snapshots:
       connect: 3.7.0
       debug: 4.4.3
       env-editor: 0.4.2
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       freeport-async: 2.0.0
       getenv: 2.0.0
       glob: 10.4.5
@@ -6168,7 +6187,7 @@ snapshots:
       postcss: 8.4.49
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6177,7 +6196,7 @@ snapshots:
   '@expo/metro-runtime@6.1.2(expo@54.0.9)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)':
     dependencies:
       anser: 1.4.10
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       pretty-format: 29.7.0
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
@@ -6234,7 +6253,7 @@ snapshots:
       '@expo/json-file': 10.0.7
       '@react-native/normalize-colors': 0.81.4
       debug: 4.4.3
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       resolve-from: 5.0.0
       semver: 7.7.2
       xml2js: 0.6.0
@@ -7710,7 +7729,7 @@ snapshots:
       resolve-from: 5.0.0
     optionalDependencies:
       '@babel/runtime': 7.28.4
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -8452,12 +8471,12 @@ snapshots:
 
   expo-application@7.0.7(expo@54.0.9):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
 
   expo-asset@12.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo/image-utils': 0.8.7
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-constants: 18.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
@@ -8471,39 +8490,45 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
+  expo-clipboard@8.0.7(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
+
   expo-constants@18.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.9
       '@expo/env': 2.0.7
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
   expo-device@8.0.9(expo@54.0.9):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       ua-parser-js: 0.7.41
 
   expo-file-system@19.0.14(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
 
   expo-font@14.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       fontfaceobserver: 2.3.0
       react: 19.1.0
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
 
   expo-haptics@15.0.7(expo@54.0.9):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
 
   expo-keep-awake@15.0.7(expo@54.0.9)(react@19.1.0):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
   expo-linking@8.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
@@ -8538,7 +8563,7 @@ snapshots:
       abort-controller: 3.0.0
       assert: 2.1.0
       badgin: 1.2.3
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-application: 7.0.7(expo@54.0.9)
       expo-constants: 18.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
       react: 19.1.0
@@ -8559,7 +8584,7 @@ snapshots:
       client-only: 0.0.1
       debug: 4.4.3
       escape-string-regexp: 4.0.0
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       expo-constants: 18.0.9(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
       expo-linking: 8.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       fast-deep-equal: 3.1.3
@@ -8593,7 +8618,7 @@ snapshots:
   expo-splash-screen@31.0.10(expo@54.0.9):
     dependencies:
       '@expo/prebuild-config': 54.0.3(expo@54.0.9)
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8605,10 +8630,10 @@ snapshots:
 
   expo-web-browser@15.0.8(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)):
     dependencies:
-      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      expo: 54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
 
-  expo@54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
+  expo@54.0.9(@babel/core@7.28.4)(@expo/metro-runtime@6.1.2)(expo-router@6.0.7)(react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@expo/cli': 54.0.7(expo-router@6.0.7)(expo@54.0.9)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
@@ -8635,6 +8660,7 @@ snapshots:
       whatwg-url-without-unicode: 8.0.0-3
     optionalDependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.9)(react-dom@19.1.0(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
+      react-native-webview: 13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@modelcontextprotocol/sdk'
@@ -10396,6 +10422,13 @@ snapshots:
       styleq: 0.1.3
     transitivePeerDependencies:
       - encoding
+
+  react-native-webview@13.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      escape-string-regexp: 4.0.0
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
 
   react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0):
     dependencies:

--- a/src/app/(settings)/open-source-licenses/index.tsx
+++ b/src/app/(settings)/open-source-licenses/index.tsx
@@ -1,0 +1,108 @@
+import { ScrollView, View, Text } from 'react-native'
+
+import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+
+const licenses = [
+  {
+    name: 'React Native',
+    license: 'MIT License',
+    description: 'A framework for building native apps using React',
+  },
+  {
+    name: 'Expo',
+    license: 'MIT License',
+    description: 'An open-source platform for making universal native apps',
+  },
+  {
+    name: 'React Navigation',
+    license: 'MIT License',
+    description: 'Routing and navigation for React Native apps',
+  },
+  {
+    name: 'Firebase',
+    license: 'Apache License 2.0',
+    description: "Google's mobile platform for app development",
+  },
+  {
+    name: 'AsyncStorage',
+    license: 'MIT License',
+    description: 'An unencrypted, asynchronous, key-value storage system',
+  },
+  {
+    name: 'React Native Safe Area Context',
+    license: 'MIT License',
+    description: 'A flexible way to handle safe area insets in React Native',
+  },
+  {
+    name: 'React Native Vector Icons',
+    license: 'MIT License',
+    description: 'Customizable icons for React Native',
+  },
+  {
+    name: 'React Query (TanStack Query)',
+    license: 'MIT License',
+    description: 'Powerful data synchronization for React',
+  },
+  {
+    name: 'Zustand',
+    license: 'MIT License',
+    description:
+      'A small, fast and scalable bearbones state-management solution',
+  },
+  {
+    name: 'Tailwind CSS',
+    license: 'MIT License',
+    description: 'A utility-first CSS framework',
+  },
+  {
+    name: 'NativeWind',
+    license: 'MIT License',
+    description: 'React Native utility-first universal design system',
+  },
+  {
+    name: 'React Native Reanimated',
+    license: 'MIT License',
+    description: "React Native's animation library",
+  },
+]
+
+export default function OpenSourceLicensesScreen() {
+  return (
+    <View className="flex-1 bg-gray-50">
+      <SettingDetailHeader title="오픈소스 라이선스" />
+
+      <ScrollView
+        className="flex-1 px-4 pt-4"
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="rounded-xl border border-gray-200 bg-white p-6">
+          <Text className="mb-6 text-base leading-6 text-gray-700">
+            동림이 앱은 다음과 같은 오픈소스 라이브러리를 사용합니다.
+          </Text>
+
+          {licenses.map((license, index) => (
+            <View
+              key={index}
+              className={`mb-4 rounded-xl border border-gray-200 bg-gray-50 p-4 ${
+                index === licenses.length - 1 ? '' : 'border-b border-gray-200'
+              }`}
+            >
+              <View className="mb-2">
+                <Text className="text-base font-semibold text-gray-900">
+                  {license.name}
+                </Text>
+                <Text className="mt-1 text-sm text-blue-600">
+                  {license.license}
+                </Text>
+              </View>
+              <Text className="mb-2 text-sm text-gray-600">
+                {license.description}
+              </Text>
+              <Text className="text-xs text-gray-500">라이선스 전문 보기</Text>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  )
+}

--- a/src/app/(settings)/open-source-licenses/index.tsx
+++ b/src/app/(settings)/open-source-licenses/index.tsx
@@ -1,72 +1,107 @@
-import { ScrollView, View, Text } from 'react-native'
+import React, { useState } from 'react'
+
+import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
 
 const licenses = [
   {
     name: 'React Native',
     license: 'MIT License',
     description: 'A framework for building native apps using React',
+    licenseUrl: 'https://github.com/facebook/react-native/blob/main/LICENSE',
   },
   {
     name: 'Expo',
     license: 'MIT License',
     description: 'An open-source platform for making universal native apps',
+    licenseUrl: 'https://github.com/expo/expo/blob/main/LICENSE',
   },
   {
     name: 'React Navigation',
     license: 'MIT License',
     description: 'Routing and navigation for React Native apps',
+    licenseUrl:
+      'https://github.com/react-navigation/react-navigation/blob/main/LICENSE',
   },
   {
     name: 'Firebase',
     license: 'Apache License 2.0',
     description: "Google's mobile platform for app development",
+    licenseUrl:
+      'https://github.com/firebase/firebase-ios-sdk/blob/master/LICENSE',
   },
   {
     name: 'AsyncStorage',
     license: 'MIT License',
     description: 'An unencrypted, asynchronous, key-value storage system',
+    licenseUrl:
+      'https://github.com/react-native-async-storage/async-storage/blob/master/LICENSE',
   },
   {
     name: 'React Native Safe Area Context',
     license: 'MIT License',
     description: 'A flexible way to handle safe area insets in React Native',
+    licenseUrl:
+      'https://github.com/th3rdwave/react-native-safe-area-context/blob/main/LICENSE',
   },
   {
     name: 'React Native Vector Icons',
     license: 'MIT License',
     description: 'Customizable icons for React Native',
+    licenseUrl:
+      'https://github.com/oblador/react-native-vector-icons/blob/master/LICENSE',
   },
   {
     name: 'React Query (TanStack Query)',
     license: 'MIT License',
     description: 'Powerful data synchronization for React',
+    licenseUrl: 'https://github.com/TanStack/query/blob/main/LICENSE',
   },
   {
     name: 'Zustand',
     license: 'MIT License',
     description:
       'A small, fast and scalable bearbones state-management solution',
+    licenseUrl: 'https://github.com/pmndrs/zustand/blob/main/LICENSE',
   },
   {
     name: 'Tailwind CSS',
     license: 'MIT License',
     description: 'A utility-first CSS framework',
+    licenseUrl:
+      'https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE',
   },
   {
     name: 'NativeWind',
     license: 'MIT License',
     description: 'React Native utility-first universal design system',
+    licenseUrl: 'https://github.com/nativewind/nativewind/blob/master/LICENSE',
   },
   {
     name: 'React Native Reanimated',
     license: 'MIT License',
     description: "React Native's animation library",
+    licenseUrl:
+      'https://github.com/software-mansion/react-native-reanimated/blob/master/LICENSE',
   },
 ]
 
 export default function OpenSourceLicensesScreen() {
+  const [browserVisible, setBrowserVisible] = useState(false)
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null)
+
+  const handleLicenseClick = (url: string) => {
+    setBrowserUrl(url)
+    setBrowserVisible(true)
+  }
+
+  const handleCloseBrowser = () => {
+    setBrowserVisible(false)
+    setBrowserUrl(null)
+  }
+
   return (
     <View className="flex-1 bg-gray-50">
       <SettingDetailHeader title="오픈소스 라이선스" />
@@ -98,11 +133,24 @@ export default function OpenSourceLicensesScreen() {
               <Text className="mb-2 text-sm text-gray-600">
                 {license.description}
               </Text>
-              <Text className="text-xs text-gray-500">라이선스 전문 보기</Text>
+              <TouchableOpacity
+                onPress={() => handleLicenseClick(license.licenseUrl)}
+                className="self-start"
+              >
+                <Text className="text-xs text-blue-600 underline">
+                  라이선스 전문 보기
+                </Text>
+              </TouchableOpacity>
             </View>
           ))}
         </View>
       </ScrollView>
+
+      <InAppBrowser
+        visible={browserVisible}
+        url={browserUrl}
+        onClose={handleCloseBrowser}
+      />
     </View>
   )
 }

--- a/src/app/(settings)/privacy-policy/index.tsx
+++ b/src/app/(settings)/privacy-policy/index.tsx
@@ -1,0 +1,87 @@
+import { useRouter } from 'expo-router'
+import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
+
+import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+
+export default function PrivacyPolicyScreen() {
+  const router = useRouter()
+
+  const handleTermsPress = () => {
+    router.push('/terms-of-service')
+  }
+
+  return (
+    <View className="flex-1 bg-gray-50">
+      <SettingDetailHeader title="개인정보 처리방침" />
+
+      <ScrollView
+        className="flex-1 px-4 pt-4"
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="rounded-xl border border-gray-200 bg-white p-6">
+          <Text className="mb-6 text-center text-lg font-semibold text-gray-900">
+            동림이 개인정보 처리방침
+          </Text>
+
+          <View className="mb-6">
+            <Text className="text-base leading-6 text-gray-700">
+              동림이(이하 "개발자")는 이용자의 개인정보 보호를 중요하게
+              생각하며, 관련 법령을 준수합니다. 이 방침은 앱 사용 시 수집되는
+              개인정보의 종류와 이용 목적, 보관 방법 및 이용자의 권리를
+              안내합니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              1. 수집하는 개인정보
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              • 디바이스 토큰: 푸시 알림 발송을 위해 수집됩니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              2. 개인정보 수집 및 이용 목적
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              • 푸시 알림 제공 및 서비스 개선
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              3. 개인정보 보관 기간
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              • 디바이스 토큰은 푸시 알림 사용 목적 달성 후 또는 이용자가 앱을
+              삭제하면 자동으로 파기됩니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              4. 이용자의 권리
+            </Text>
+            <Text className="mb-3 text-base leading-6 text-gray-700">
+              • 이용자는 언제든지 알림 수신 동의를 철회할 수 있습니다.
+            </Text>
+            <TouchableOpacity onPress={handleTermsPress}>
+              <Text className="text-base font-medium text-blue-600 underline">
+                서비스 이용약관 자세히 보기
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <View className="border-t border-gray-200 pt-4">
+            <Text className="text-center text-sm text-gray-500">
+              본 방침은 2025년 10월 23일부터 시행됩니다.{'\n'}
+              최종 수정일: 2025년 10월 23일
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}

--- a/src/app/(settings)/suggestion/index.tsx
+++ b/src/app/(settings)/suggestion/index.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+
+import {
+  ScrollView,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+
+import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+
+const suggestionTypes = [
+  {
+    id: 'bug',
+    label: '🐛 버그 신고',
+    description: '앱에서 발생한 오류나 버그',
+  },
+  {
+    id: 'feature',
+    label: '💡 기능 제안',
+    description: '새로운 기능이나 개선사항',
+  },
+  { id: 'ui', label: '🎨 UI/UX 개선', description: '디자인이나 사용성 개선' },
+  { id: 'etc', label: '📝 기타 문의', description: '기타 문의사항이나 건의' },
+]
+
+export default function SuggestionScreen() {
+  const [selectedType, setSelectedType] = useState<string>('')
+  const [title, setTitle] = useState('')
+  const [content, setContent] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    if (!selectedType || !title.trim() || !content.trim()) {
+      Alert.alert('입력 오류', '모든 필드를 입력해주세요.')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      // TODO: Firebase나 API로 데이터 전송
+      console.log('건의사항 전송:', {
+        type: selectedType,
+        title,
+        content,
+        timestamp: new Date().toISOString(),
+      })
+
+      // 임시로 성공 처리
+      Alert.alert(
+        '전송 완료',
+        '소중한 의견 감사합니다! 빠른 시일 내에 검토하겠습니다.',
+        [
+          {
+            text: '확인',
+            onPress: () => {
+              setSelectedType('')
+              setTitle('')
+              setContent('')
+            },
+          },
+        ]
+      )
+    } catch (error) {
+      console.error('건의사항 전송 실패:', error)
+      Alert.alert('전송 실패', '잠시 후 다시 시도해주세요.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <View className="flex-1 bg-gray-50">
+      <SettingDetailHeader title="건의하기" />
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4 pt-4"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* 문의 유형 선택 */}
+          <View className="mb-6">
+            <Text className="mb-3 text-lg font-semibold text-gray-900">
+              문의 유형
+            </Text>
+            <View className="flex-row flex-wrap gap-2">
+              {suggestionTypes.map((type) => (
+                <TouchableOpacity
+                  key={type.id}
+                  className={`rounded-xl border p-3 ${
+                    selectedType === type.id
+                      ? 'border-blue-500 bg-blue-50'
+                      : 'border-gray-200 bg-white'
+                  }`}
+                  onPress={() => setSelectedType(type.id)}
+                  style={{ width: '23%' }}
+                >
+                  <Text className="text-center text-2xl">
+                    {type.label.split(' ')[0]}
+                  </Text>
+                  <Text
+                    className={`mt-1 text-center text-xs font-medium ${
+                      selectedType === type.id
+                        ? 'text-blue-700'
+                        : 'text-gray-900'
+                    }`}
+                  >
+                    {type.label.split(' ')[1]}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* 제목 입력 */}
+          <View className="mb-6">
+            <Text className="mb-3 text-lg font-semibold text-gray-900">
+              제목
+            </Text>
+            <TextInput
+              className="rounded-xl border border-gray-200 bg-white p-4 text-base"
+              placeholder="제목을 입력해주세요"
+              value={title}
+              onChangeText={setTitle}
+              maxLength={100}
+            />
+          </View>
+
+          {/* 내용 입력 */}
+          <View className="mb-6">
+            <Text className="mb-3 text-lg font-semibold text-gray-900">
+              내용
+            </Text>
+            <TextInput
+              className="rounded-xl border border-gray-200 bg-white p-4 text-base"
+              placeholder="자세한 내용을 입력해주세요"
+              value={content}
+              onChangeText={setContent}
+              multiline
+              textAlignVertical="top"
+              style={{ height: 150 }}
+              maxLength={1000}
+            />
+            <Text className="mt-2 text-right text-sm text-gray-500">
+              {content.length}/1000
+            </Text>
+          </View>
+
+          {/* 전송 버튼 */}
+          <TouchableOpacity
+            className={`mb-8 rounded-xl p-4 ${
+              isSubmitting || !selectedType || !title.trim() || !content.trim()
+                ? 'bg-gray-300'
+                : 'bg-blue-500'
+            }`}
+            onPress={handleSubmit}
+            disabled={
+              isSubmitting || !selectedType || !title.trim() || !content.trim()
+            }
+          >
+            <Text className="text-center text-lg font-semibold text-white">
+              {isSubmitting ? '전송 중...' : '건의사항 전송'}
+            </Text>
+          </TouchableOpacity>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  )
+}

--- a/src/app/(settings)/suggestion/index.tsx
+++ b/src/app/(settings)/suggestion/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 
+import { addDoc, collection, serverTimestamp } from 'firebase/firestore'
 import {
   ScrollView,
   View,
@@ -12,6 +13,7 @@ import {
 } from 'react-native'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+import { db } from '@/config/firebaseConfig'
 
 const suggestionTypes = [
   {
@@ -34,6 +36,7 @@ export default function SuggestionScreen() {
   const [content, setContent] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  // 건의사항 전송
   const handleSubmit = async () => {
     if (!selectedType || !title.trim() || !content.trim()) {
       Alert.alert('입력 오류', '모든 필드를 입력해주세요.')
@@ -43,15 +46,13 @@ export default function SuggestionScreen() {
     setIsSubmitting(true)
 
     try {
-      // TODO: Firebase나 API로 데이터 전송
-      console.log('건의사항 전송:', {
+      await addDoc(collection(db, 'suggestions'), {
         type: selectedType,
-        title,
-        content,
-        timestamp: new Date().toISOString(),
+        title: title.trim(),
+        content: content.trim(),
+        timestamp: serverTimestamp(), // 서버 기준 시간
       })
 
-      // 임시로 성공 처리
       Alert.alert(
         '전송 완료',
         '소중한 의견 감사합니다! 빠른 시일 내에 검토하겠습니다.',
@@ -159,7 +160,7 @@ export default function SuggestionScreen() {
             className={`mb-8 rounded-xl p-4 ${
               isSubmitting || !selectedType || !title.trim() || !content.trim()
                 ? 'bg-gray-300'
-                : 'bg-blue-500'
+                : 'bg-deu-light-blue'
             }`}
             onPress={handleSubmit}
             disabled={

--- a/src/app/(settings)/terms-of-service/index.tsx
+++ b/src/app/(settings)/terms-of-service/index.tsx
@@ -1,0 +1,136 @@
+import { useRouter } from 'expo-router'
+import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
+
+import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
+
+export default function TermsOfServiceScreen() {
+  const router = useRouter()
+
+  const handlePrivacyPolicyPress = () => {
+    router.push('/privacy-policy')
+  }
+
+  return (
+    <View className="flex-1 bg-gray-50">
+      <SettingDetailHeader title="이용 약관" />
+
+      <ScrollView
+        className="flex-1 px-4 pt-4"
+        showsVerticalScrollIndicator={false}
+      >
+        <View className="rounded-xl border border-gray-200 bg-white p-6">
+          <Text className="mb-6 text-center text-lg font-semibold text-gray-900">
+            동림이 서비스 이용 약관
+          </Text>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제1조 (목적)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              이 약관은 동림이(이하 "개발자")가 제공하는 서비스의 이용 조건과
+              절차, 개발자와 이용자의 권리·의무를 규정하는 것을 목적으로 합니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제2조 (용어의 정의)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              • "서비스"란 개발자가 제공하는 모든 기능과 콘텐츠를 의미합니다.
+              {'\n'}• "이용자"란 서비스 이용을 위해 동림이에 접속하거나 사용하는
+              사람을 의미합니다.{'\n'}• "콘텐츠"란 서비스에서 제공되는 텍스트,
+              이미지, 영상, 기타 자료를 의미합니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제3조 (약관의 게시 및 개정)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              1. 개발자는 약관을 앱 내에 게시하거나 공지합니다.{'\n'}
+              2. 개발자는 필요 시 약관을 변경할 수 있으며, 변경 사항은 공지한
+              날로부터 7일 후 효력을 가집니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제4조 (서비스 제공 및 변경)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              1. 개발자는 다음과 같은 서비스를 제공합니다:{'\n'}
+              {'  '}• 학사 공지사항 확인{'\n'}
+              {'  '}• 알림 서비스{'\n'}
+              {'  '}• 기타 부가 기능{'\n'}
+              2. 개발자는 서비스 내용, 이용 방법, 이용 시간을 변경할 수 있으며,
+              변경 시 사전에 공지합니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제5조 (이용자의 의무)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              1. 이용자는 약관과 서비스 이용 안내를 준수해야 합니다.{'\n'}
+              2. 이용자는 다음 행위를 해서는 안 됩니다:{'\n'}
+              {'  '}• 타인의 정보 도용{'\n'}
+              {'  '}• 서비스 안정성을 방해하는 행위{'\n'}
+              {'  '}• 허위 정보 등록{'\n'}
+              {'  '}• 법령 또는 공서양속에 위반되는 행위
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제6조 (개인정보 보호)
+            </Text>
+            <Text className="mb-3 text-base leading-6 text-gray-700">
+              개발자는 이용자의 개인정보를 보호하며, 개인정보 처리방침에 따라
+              관리합니다.{' '}
+            </Text>
+            <TouchableOpacity onPress={handlePrivacyPolicyPress}>
+              <Text className="text-base font-medium text-blue-600 underline">
+                개인정보 처리방침은 앱 내에서 확인하실 수 있습니다.
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제7조 (서비스 중단)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              1. 개발자는 시스템 점검, 서비스 장애, 외부 요인 등으로 서비스를
+              일시 중단할 수 있습니다.{'\n'}
+              2. 서비스 중단으로 발생하는 이용자 피해에 대해서는 책임을 지지
+              않습니다.
+            </Text>
+          </View>
+
+          <View className="mb-6">
+            <Text className="mb-2 text-base font-semibold text-gray-900">
+              제8조 (면책 사항)
+            </Text>
+            <Text className="text-base leading-6 text-gray-700">
+              1. 개발자는 천재지변 등 불가항력적 상황으로 인한 서비스 중단에
+              대해 책임을 지지 않습니다.{'\n'}
+              2. 개발자는 이용자가 서비스를 사용하여 얻는 결과나 이익에 대해
+              보장하지 않습니다.
+            </Text>
+          </View>
+
+          <View className="border-t border-gray-200 pt-4">
+            <Text className="text-center text-sm text-gray-500">
+              본 약관은 2025년 10월 23일부터 시행됩니다.{'\n'}
+              최종 수정일: 2025년 10월 23일
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -42,6 +42,19 @@ export default function TabLayout() {
             header: () => <HomeHeader />,
             tabBarShowLabel: false,
           }}
+          // 홈 탭에서만 스와이프 활성화/비활성화
+          listeners={({ navigation }) => ({
+            focus: () => {
+              navigation.getParent()?.setOptions({
+                swipeEnabled: true,
+              })
+            },
+            blur: () => {
+              navigation.getParent()?.setOptions({
+                swipeEnabled: false,
+              })
+            },
+          })}
         />
         <Tabs.Screen
           name="notification"

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -26,7 +26,10 @@ export default function RootLayout() {
         <BottomSheetModalProvider>
           <Drawer
             drawerContent={(props) => <HomeDrawer {...props} />}
-            screenOptions={{ headerShown: false }}
+            screenOptions={{
+              headerShown: false,
+              swipeEnabled: false,
+            }}
           >
             <Drawer.Screen
               name="(tabs)"

--- a/src/app/homepage-search/index.tsx
+++ b/src/app/homepage-search/index.tsx
@@ -38,8 +38,7 @@ export default function HomepageSearch() {
   const { searchHistory, addHistory, removeHistory, clearHistory } =
     useSearchStore()
 
-  // 임시 공지사항 데이터
-  const { data: notices = [] } = useFetchNotices(100)
+  const { data: notices = [] } = useFetchNotices(20)
 
   // 검색어 변경 핸들러
   const handleSearchTermChange = (term: string) => {
@@ -88,9 +87,9 @@ export default function HomepageSearch() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView className="flex-1 bg-white px-4">
+      <SafeAreaView className="flex-1 bg-white">
         {/* 헤더 부분 */}
-        <View className="flex-row items-center gap-4">
+        <View className="flex-row items-center gap-4 px-4">
           <TouchableOpacity onPress={handleBack}>
             <Ionicons name="arrow-back" size={24} color="black" />
           </TouchableOpacity>
@@ -98,7 +97,7 @@ export default function HomepageSearch() {
         </View>
 
         {/* 검색 입력 부분 */}
-        <View className="relative justify-center py-6">
+        <View className="relative justify-center px-4 py-6">
           <TextInput
             ref={inputRef}
             className="h-12 rounded-xl bg-gray-100 py-0 pl-11 text-base"
@@ -110,7 +109,7 @@ export default function HomepageSearch() {
             onSubmitEditing={() => executeSearch(searchTerm)}
             style={{ textAlignVertical: 'center' }}
           />
-          <View className="absolute bottom-0 left-3 top-0 justify-center">
+          <View className="absolute bottom-0 left-7 top-0 justify-center">
             <Ionicons name="search" size={20} color="#999999" />
           </View>
         </View>
@@ -127,14 +126,14 @@ export default function HomepageSearch() {
                 onScrollBeginDrag={Keyboard.dismiss}
               />
             ) : (
-              <View className="flex-1 items-center">
+              <View className="flex-1 items-center px-4">
                 <Text className="text-lg text-gray-400">
                   검색 결과가 없습니다.
                 </Text>
               </View>
             )
           ) : searchHistory.length > 0 ? (
-            <View>
+            <View className="px-4">
               <View className="mb-4 flex-row items-center justify-between">
                 <Text className="text-base font-semibold">최근 검색</Text>
                 <View className="flex flex-row items-center justify-center gap-4">

--- a/src/app/notification-setting/index.tsx
+++ b/src/app/notification-setting/index.tsx
@@ -17,7 +17,7 @@ export default function NotificationSetting() {
     selectedKeywords,
     selectedDepartments,
     notificationEnabled,
-    setNotificationEnabled,
+    handleNotificationToggle,
     handleKeywordUpdate,
     handleDepartmentUpdate,
     handleKeywordRemove,
@@ -81,18 +81,24 @@ export default function NotificationSetting() {
       <NotificationSettingHeader />
 
       <View className="gap-5 px-4">
-        {/* 전체 푸시 알림 설정 섹션 */}
+        {/* 푸시 알림 설정 섹션 */}
         <View className="rounded-xl border border-gray-200 bg-white px-4 py-4">
           <View className="flex-row items-center justify-between">
-            <Text className="font-semibold">🔔 전체 푸시 알림 받기</Text>
+            <Text className="font-semibold">🔔 푸시 알림 받기</Text>
 
             <Switch
               value={notificationEnabled}
-              onValueChange={setNotificationEnabled}
+              onValueChange={handleNotificationToggle}
               trackColor={{ false: '#D1D5DB', true: '#93C5FD' }}
               thumbColor={notificationEnabled ? '#093a87' : '#F3F4F6'}
             />
           </View>
+          {/* 푸시 알림 설정 설명 - OFF 상태일 때만 표시 */}
+          {!notificationEnabled && (
+            <Text className="text-sm text-gray-500">
+              푸시 알림이 꺼져 있습니다. 알림을 받고 싶다면 켜주세요.
+            </Text>
+          )}
         </View>
 
         {/* 키워드 알림 설정 섹션 */}

--- a/src/components/layout/SettingDetailHeader/SettingDetailHeader.tsx
+++ b/src/components/layout/SettingDetailHeader/SettingDetailHeader.tsx
@@ -1,0 +1,22 @@
+import { Ionicons } from '@expo/vector-icons'
+import { useRouter } from 'expo-router'
+import { TouchableOpacity, Text, View } from 'react-native'
+
+interface SettingDetailHeaderProps {
+  title: string
+}
+
+export default function SettingDetailHeader({
+  title,
+}: SettingDetailHeaderProps) {
+  const router = useRouter()
+
+  return (
+    <View className="flex-row items-center gap-4 bg-white px-4 pt-20">
+      <TouchableOpacity onPress={() => router.back()}>
+        <Ionicons name="arrow-back" size={24} color="black" />
+      </TouchableOpacity>
+      <Text className="text-2xl font-bold">{title}</Text>
+    </View>
+  )
+}

--- a/src/components/layout/SettingHeader/SettingHeader.tsx
+++ b/src/components/layout/SettingHeader/SettingHeader.tsx
@@ -1,24 +1,9 @@
-import { Feather } from '@expo/vector-icons'
-import { DrawerActions } from '@react-navigation/native'
-import { useNavigation, useRouter } from 'expo-router'
 import { Text } from 'react-native'
-import { Platform, TouchableOpacity, View } from 'react-native'
+import { Platform, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export function SettingHeader() {
-  const router = useRouter()
-  const navigation = useNavigation()
   const { top } = useSafeAreaInsets()
-
-  // 사이드바 메뉴 열기
-  const openMenu = () => {
-    navigation.dispatch(DrawerActions.openDrawer())
-  }
-
-  // 마이페이지 설정 페이지로 이동
-  const goToSearch = () => {
-    // router.push('/mypage-settings')
-  }
 
   return (
     <View
@@ -27,13 +12,7 @@ export function SettingHeader() {
         paddingTop: Platform.OS === 'android' ? top + 10 : top,
       }}
     >
-      <TouchableOpacity onPress={openMenu} style={{ padding: 8 }}>
-        <Text className="text-2xl font-semibold">마이페이지</Text>
-      </TouchableOpacity>
-
-      <TouchableOpacity onPress={goToSearch} style={{ padding: 8 }}>
-        <Feather name="settings" size={24} color="#999999" />
-      </TouchableOpacity>
+      <Text className="text-2xl font-semibold">설정</Text>
     </View>
   )
 }

--- a/src/components/notice/NoticeContent/NoticeContent.tsx
+++ b/src/components/notice/NoticeContent/NoticeContent.tsx
@@ -1,13 +1,13 @@
-import { useRef, useMemo } from 'react'
+import { useRef, useMemo, useState } from 'react'
 
 import { Ionicons } from '@expo/vector-icons'
 import * as Haptics from 'expo-haptics'
-import * as WebBrowser from 'expo-web-browser'
 import { View, Text, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
 
+import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
 import RightSwipeActions from '@/components/ui/RightSwipeActions/RightSwipeActions'
 import { useScrapStore } from '@/store/scrapStore'
 import { Notice } from '@/types/notice.type'
@@ -27,6 +27,10 @@ export const NoticeContent = ({ item }: NoticeContentProps) => {
 
   // 스와이프 참조
   const swipeableRef = useRef<SwipeableMethods>(null)
+
+  // 인앱 브라우저 상태
+  const [browserVisible, setBrowserVisible] = useState(false)
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null)
 
   // 현재 공지가 스크랩되어 있는지 확인
   const isScraped = useMemo(() => {
@@ -59,68 +63,84 @@ export const NoticeContent = ({ item }: NoticeContentProps) => {
   // 공지 링크 열기
   const handleOpenLink = () => {
     if (item.link) {
-      WebBrowser.openBrowserAsync(item.link)
+      setBrowserUrl(item.link)
+      setBrowserVisible(true)
     }
   }
 
   return (
-    <Swipeable
-      ref={swipeableRef}
-      renderRightActions={() => (
-        <RightSwipeActions
-          onPress={isScraped ? handleRemoveScrap : handleAddScrap}
-          isScraped={isScraped}
-        />
-      )}
-      onSwipeableWillOpen={handleSwipeableWillOpen}
-      containerStyle={{
-        marginBottom: 10,
-      }}
-      overshootLeft={false}
-      overshootRight={false}
-    >
-      <TouchableOpacity
-        className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t border-gray-200 bg-white p-5 pr-4"
-        onPress={handleOpenLink}
-        activeOpacity={0.7}
+    <>
+      <Swipeable
+        ref={swipeableRef}
+        renderRightActions={() => (
+          <RightSwipeActions
+            onPress={isScraped ? handleRemoveScrap : handleAddScrap}
+            isScraped={isScraped}
+          />
+        )}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        containerStyle={{
+          marginBottom: 10,
+        }}
+        overshootLeft={false}
+        overshootRight={false}
       >
-        <View className="flex-1 justify-between">
-          <View className="flex-row items-start justify-between">
-            <Text
-              className="flex-1 pr-2 text-base font-medium leading-snug text-gray-900"
-              numberOfLines={2}
-            >
-              {item.title}
-            </Text>
-            {isScraped && (
-              <Ionicons name="bookmark" size={20} color="#0158a6" />
-            )}
-          </View>
-
-          <View className="flex-row items-center justify-between gap-3">
-            <View className="flex-1 flex-row items-center gap-2">
-              <View className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}>
-                <Text className={`text-xs font-medium ${departmentStyle.text}`}>
-                  {item.department}
-                </Text>
-              </View>
-
-              <View className="flex-1 flex-row flex-wrap gap-1.5">
-                {item.tags.slice(0, 2).map((tag) => (
-                  <View key={tag} className="rounded-md bg-gray-100 px-2 py-1">
-                    <Text className="text-xs font-medium text-gray-600">
-                      #{tag}
-                    </Text>
-                  </View>
-                ))}
-              </View>
+        <TouchableOpacity
+          className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t border-gray-200 bg-white p-5 pr-4"
+          onPress={handleOpenLink}
+          activeOpacity={0.7}
+        >
+          <View className="flex-1 justify-between">
+            <View className="flex-row items-start justify-between">
+              <Text
+                className="flex-1 pr-2 text-base font-medium leading-snug text-gray-900"
+                numberOfLines={2}
+              >
+                {item.title}
+              </Text>
+              {isScraped && (
+                <Ionicons name="bookmark" size={20} color="#0158a6" />
+              )}
             </View>
-            <Text className="text-xs font-normal text-gray-500">
-              {getFormattedDate(item.saved_at)}
-            </Text>
+
+            <View className="flex-row items-center justify-between gap-3">
+              <View className="flex-1 flex-row items-center gap-2">
+                <View
+                  className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}
+                >
+                  <Text
+                    className={`text-xs font-medium ${departmentStyle.text}`}
+                  >
+                    {item.department}
+                  </Text>
+                </View>
+
+                <View className="flex-1 flex-row flex-wrap gap-1.5">
+                  {item.tags.slice(0, 2).map((tag) => (
+                    <View
+                      key={tag}
+                      className="rounded-md bg-gray-100 px-2 py-1"
+                    >
+                      <Text className="text-xs font-medium text-gray-600">
+                        #{tag}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+              <Text className="text-xs font-normal text-gray-500">
+                {getFormattedDate(item.saved_at)}
+              </Text>
+            </View>
           </View>
-        </View>
-      </TouchableOpacity>
-    </Swipeable>
+        </TouchableOpacity>
+      </Swipeable>
+
+      <InAppBrowser
+        visible={browserVisible}
+        url={browserUrl}
+        onClose={() => setBrowserVisible(false)}
+      />
+    </>
   )
 }

--- a/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
+++ b/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
@@ -1,12 +1,12 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
 import * as Haptics from 'expo-haptics'
-import * as WebBrowser from 'expo-web-browser'
 import { View, Text, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
 
+import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
 import RightSwipeActions from '@/components/ui/RightSwipeActions/RightSwipeActions'
 import { PushNotificationItem } from '@/types/notification.type'
 import { getFormattedDate } from '@/utils/dateUtils'
@@ -74,6 +74,10 @@ function NotificationItemContent({
   // 스와이프 참조
   const swipeableRef = useRef<SwipeableMethods>(null)
 
+  // 인앱 브라우저 상태
+  const [browserVisible, setBrowserVisible] = useState(false)
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null)
+
   // 부서 스타일 가져오기
   const departmentStyle = item.department
     ? getDepartmentStyles(item.department)
@@ -94,7 +98,8 @@ function NotificationItemContent({
   // 알림 탭: 브라우저 열고(있으면) 상위 onPress 호출
   const handlePress = () => {
     if (item.noticeLink) {
-      WebBrowser.openBrowserAsync(item.noticeLink)
+      setBrowserUrl(item.noticeLink)
+      setBrowserVisible(true)
     }
     onPress?.({
       id: item.id,
@@ -104,87 +109,97 @@ function NotificationItemContent({
   }
 
   return (
-    <Swipeable
-      ref={swipeableRef}
-      renderRightActions={() => (
-        <RightSwipeActions
-          onPress={handleDelete}
-          isScraped={false}
-          isDeleteOnly={true} // 알림은 삭제만 가능
-        />
-      )}
-      onSwipeableWillOpen={handleSwipeableWillOpen}
-      containerStyle={{
-        marginBottom: 10,
-      }}
-      overshootLeft={false}
-      overshootRight={false}
-    >
-      <TouchableOpacity
-        className={`ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t ${
-          item.read ? 'border-gray-200 bg-white' : 'border-blue-200 bg-blue-50'
-        } p-5 pr-4`}
-        onPress={handlePress}
-        activeOpacity={0.7}
+    <>
+      <Swipeable
+        ref={swipeableRef}
+        renderRightActions={() => (
+          <RightSwipeActions
+            onPress={handleDelete}
+            isScraped={false}
+            isDeleteOnly={true} // 알림은 삭제만 가능
+          />
+        )}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        containerStyle={{
+          marginBottom: 10,
+        }}
+        overshootLeft={false}
+        overshootRight={false}
       >
-        <View className="flex-1 justify-between">
-          <View className="flex-row items-start justify-between">
-            <Text
-              className={`flex-1 pr-2 text-base font-medium leading-snug ${
-                item.read ? 'text-gray-900' : 'text-gray-800'
-              }`}
-              numberOfLines={2}
-            >
-              {item.title}
-            </Text>
-            {!item.read && (
-              <View className="h-2 w-2 rounded-full bg-blue-500" />
-            )}
-          </View>
-
-          <View className="flex-row items-center justify-between gap-3">
-            <View className="flex-1 flex-row items-center gap-2">
-              {item.department && departmentStyle && (
-                <View
-                  className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}
-                >
-                  <Text
-                    className={`text-xs font-medium ${departmentStyle.text}`}
-                  >
-                    {item.department}
-                  </Text>
-                </View>
-              )}
-
-              {item.category && (
-                <View className="rounded-md bg-gray-100 px-2 py-1">
-                  <Text className="text-xs font-medium text-gray-600">
-                    #{item.category}
-                  </Text>
-                </View>
-              )}
-
-              {item.tags && item.tags.length > 0 && (
-                <View className="flex-1 flex-row flex-wrap gap-1.5">
-                  {item.tags.slice(0, 2).map((tag) => (
-                    <View
-                      key={tag}
-                      className="rounded-md bg-gray-100 px-2 py-1"
-                    >
-                      <Text className="text-xs font-medium text-gray-600">
-                        #{tag}
-                      </Text>
-                    </View>
-                  ))}
-                </View>
+        <TouchableOpacity
+          className={`ml-4 mr-0 min-h-[105px] rounded-l-lg border-b border-l border-t ${
+            item.read
+              ? 'border-gray-200 bg-white'
+              : 'border-blue-200 bg-blue-50'
+          } p-5 pr-4`}
+          onPress={handlePress}
+          activeOpacity={0.7}
+        >
+          <View className="flex-1 justify-between">
+            <View className="flex-row items-start justify-between">
+              <Text
+                className={`flex-1 pr-2 text-base font-medium leading-snug ${
+                  item.read ? 'text-gray-900' : 'text-gray-800'
+                }`}
+                numberOfLines={2}
+              >
+                {item.title}
+              </Text>
+              {!item.read && (
+                <View className="h-2 w-2 rounded-full bg-blue-500" />
               )}
             </View>
-            <Text className="text-xs font-normal text-gray-500">
-              {getFormattedDate(item.createdAtMs)}
-            </Text>
+
+            <View className="flex-row items-center justify-between gap-3">
+              <View className="flex-1 flex-row items-center gap-2">
+                {item.department && departmentStyle && (
+                  <View
+                    className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}
+                  >
+                    <Text
+                      className={`text-xs font-medium ${departmentStyle.text}`}
+                    >
+                      {item.department}
+                    </Text>
+                  </View>
+                )}
+
+                {item.category && (
+                  <View className="rounded-md bg-gray-100 px-2 py-1">
+                    <Text className="text-xs font-medium text-gray-600">
+                      #{item.category}
+                    </Text>
+                  </View>
+                )}
+
+                {item.tags && item.tags.length > 0 && (
+                  <View className="flex-1 flex-row flex-wrap gap-1.5">
+                    {item.tags.slice(0, 2).map((tag) => (
+                      <View
+                        key={tag}
+                        className="rounded-md bg-gray-100 px-2 py-1"
+                      >
+                        <Text className="text-xs font-medium text-gray-600">
+                          #{tag}
+                        </Text>
+                      </View>
+                    ))}
+                  </View>
+                )}
+              </View>
+              <Text className="text-xs font-normal text-gray-500">
+                {getFormattedDate(item.createdAtMs)}
+              </Text>
+            </View>
           </View>
-        </View>
-      </TouchableOpacity>
-    </Swipeable>
+        </TouchableOpacity>
+      </Swipeable>
+
+      <InAppBrowser
+        visible={browserVisible}
+        url={browserUrl}
+        onClose={() => setBrowserVisible(false)}
+      />
+    </>
   )
 }

--- a/src/components/scrap/ScrapItem/ScrapItem.tsx
+++ b/src/components/scrap/ScrapItem/ScrapItem.tsx
@@ -1,12 +1,12 @@
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 
 import * as Haptics from 'expo-haptics'
-import * as WebBrowser from 'expo-web-browser'
 import { Text, View, TouchableOpacity } from 'react-native'
 import Swipeable, {
   SwipeableMethods,
 } from 'react-native-gesture-handler/ReanimatedSwipeable'
 
+import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
 import RightSwipeActions from '@/components/ui/RightSwipeActions/RightSwipeActions'
 import { Scrap, useScrapStore } from '@/store/scrapStore'
 import { getFormattedDate } from '@/utils/dateUtils'
@@ -17,6 +17,10 @@ export const ScrapItem = ({ scrap }: { scrap: Scrap }) => {
   const { removeScrap } = useScrapStore()
   const departmentStyle = getDepartmentStyles(scrap.notice.department)
   const swipeableRef = useRef<SwipeableMethods>(null)
+
+  // 인앱 브라우저 상태
+  const [browserVisible, setBrowserVisible] = useState(false)
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null)
 
   // 스크랩 삭제 핸들러
   const handleRemoveScrap = () => {
@@ -33,63 +37,79 @@ export const ScrapItem = ({ scrap }: { scrap: Scrap }) => {
   // 링크 열기
   const handleOpenLink = () => {
     if (scrap.notice.link) {
-      WebBrowser.openBrowserAsync(scrap.notice.link)
+      setBrowserUrl(scrap.notice.link)
+      setBrowserVisible(true)
     }
   }
 
   return (
-    <Swipeable
-      ref={swipeableRef}
-      renderRightActions={() => (
-        <RightSwipeActions onPress={handleRemoveScrap} isScraped={true} />
-      )}
-      onSwipeableWillOpen={handleSwipeableWillOpen}
-      containerStyle={{
-        marginBottom: 12,
-      }}
-      overshootLeft={false}
-      overshootRight={false}
-    >
-      <TouchableOpacity
-        className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-l-4 border-deu-light-blue bg-white p-5 pr-4"
-        onPress={handleOpenLink}
-        activeOpacity={0.7}
+    <>
+      <Swipeable
+        ref={swipeableRef}
+        renderRightActions={() => (
+          <RightSwipeActions onPress={handleRemoveScrap} isScraped={true} />
+        )}
+        onSwipeableWillOpen={handleSwipeableWillOpen}
+        containerStyle={{
+          marginBottom: 12,
+        }}
+        overshootLeft={false}
+        overshootRight={false}
       >
-        <View className="flex-1 justify-between">
-          <View className="flex-row items-start justify-between">
-            <Text
-              className="text-base font-medium text-gray-900"
-              numberOfLines={2}
-            >
-              {scrap.notice.title}
-            </Text>
-          </View>
-
-          <View className="mt-3 flex-row items-center justify-between gap-3">
-            <View className="flex-1 flex-row items-center gap-2">
-              <View className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}>
-                <Text className={`text-xs font-medium ${departmentStyle.text}`}>
-                  {scrap.notice.department}
-                </Text>
-              </View>
-
-              <View className="flex-1 flex-row flex-wrap gap-1.5">
-                {scrap.notice.tags.slice(0, 2).map((tag) => (
-                  <View key={tag} className="rounded-md bg-gray-100 px-2 py-1">
-                    <Text className="text-xs font-medium text-gray-600">
-                      #{tag}
-                    </Text>
-                  </View>
-                ))}
-              </View>
+        <TouchableOpacity
+          className="ml-4 mr-0 min-h-[105px] rounded-l-lg border-l-4 border-deu-light-blue bg-white p-5 pr-4"
+          onPress={handleOpenLink}
+          activeOpacity={0.7}
+        >
+          <View className="flex-1 justify-between">
+            <View className="flex-row items-start justify-between">
+              <Text
+                className="text-base font-medium text-gray-900"
+                numberOfLines={2}
+              >
+                {scrap.notice.title}
+              </Text>
             </View>
 
-            <Text className="text-xs font-normal text-gray-500">
-              {getFormattedDate(scrap.notice.saved_at)}
-            </Text>
+            <View className="mt-3 flex-row items-center justify-between gap-3">
+              <View className="flex-1 flex-row items-center gap-2">
+                <View
+                  className={`rounded-md px-2.5 py-1 ${departmentStyle.bg}`}
+                >
+                  <Text
+                    className={`text-xs font-medium ${departmentStyle.text}`}
+                  >
+                    {scrap.notice.department}
+                  </Text>
+                </View>
+
+                <View className="flex-1 flex-row flex-wrap gap-1.5">
+                  {scrap.notice.tags.slice(0, 2).map((tag) => (
+                    <View
+                      key={tag}
+                      className="rounded-md bg-gray-100 px-2 py-1"
+                    >
+                      <Text className="text-xs font-medium text-gray-600">
+                        #{tag}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              </View>
+
+              <Text className="text-xs font-normal text-gray-500">
+                {getFormattedDate(scrap.notice.saved_at)}
+              </Text>
+            </View>
           </View>
-        </View>
-      </TouchableOpacity>
-    </Swipeable>
+        </TouchableOpacity>
+      </Swipeable>
+
+      <InAppBrowser
+        visible={browserVisible}
+        url={browserUrl}
+        onClose={() => setBrowserVisible(false)}
+      />
+    </>
   )
 }

--- a/src/components/setting/SettingContent/SettingContent.tsx
+++ b/src/components/setting/SettingContent/SettingContent.tsx
@@ -1,5 +1,6 @@
 import { Feather } from '@expo/vector-icons'
 import AsyncStorage from '@react-native-async-storage/async-storage'
+import { useRouter } from 'expo-router'
 import { View, Text, TouchableOpacity, Alert } from 'react-native'
 
 import { useCategoryFilterStore } from '@/store/categoryFilterStore'
@@ -8,17 +9,44 @@ import { useScrapStore } from '@/store/scrapStore'
 import { useSearchStore } from '@/store/searchStore'
 import { queryClient } from '@/utils/queryClient'
 
+const appSupportMenus = [
+  { id: 'notifications', title: '알림 설정' },
+  { id: 'help', title: '건의하기' },
+] as const
+
 const appInfoMenus = [
-  { id: 'notice', title: '공지사항' },
-  { id: 'help', title: '도움말 및 문의하기' },
-  { id: 'service', title: '서비스 정보' },
+  { id: 'terms', title: '이용 약관' },
+  { id: 'privacy', title: '개인정보 처리방침' },
+  { id: 'license', title: '오픈소스 라이선스' },
 ] as const
 
 export default function SettingContent() {
+  const router = useRouter()
   const { resetSettings } = useNotificationStore()
   const { clearCategory } = useCategoryFilterStore()
   const { scraps, setSortPreference } = useScrapStore()
   const { clearHistory } = useSearchStore()
+
+  const handleMenuPress = (menuId: string) => {
+    switch (menuId) {
+      case 'notifications':
+        router.push('/notification-setting')
+        break
+      case 'help':
+        router.push('/suggestion')
+        break
+      case 'terms':
+        router.push('/terms-of-service')
+        break
+      case 'privacy':
+        router.push('/privacy-policy')
+        break
+      case 'license':
+        router.push('/open-source-licenses')
+        break
+      default:
+    }
+  }
 
   const handleDevReset = () => {
     Alert.alert(
@@ -53,12 +81,29 @@ export default function SettingContent() {
   }
   return (
     <View className="gap-6 p-4">
-      {/* 앱 정보 및 지원 */}
+      {/* 앱 지원 */}
       <View className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <View className="border-b border-gray-200 px-4 py-3">
-          <Text className="text-base font-semibold text-gray-900">
-            앱 정보 및 지원
-          </Text>
+          <Text className="text-base font-semibold text-gray-900">앱 지원</Text>
+        </View>
+        {appSupportMenus.map((menu, index) => (
+          <TouchableOpacity
+            key={menu.id}
+            className={`flex-row items-center justify-between border-b border-gray-200 px-4 py-3.5 ${
+              index === appSupportMenus.length - 1 ? 'border-b-0' : ''
+            }`}
+            onPress={() => handleMenuPress(menu.id)}
+          >
+            <Text className="text-base text-gray-800">{menu.title}</Text>
+            <Feather name="chevron-right" size={22} color="#A0A0A0" />
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* 앱 정보 */}
+      <View className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <View className="border-b border-gray-200 px-4 py-3">
+          <Text className="text-base font-semibold text-gray-900">앱 정보</Text>
         </View>
         {appInfoMenus.map((menu, index) => (
           <TouchableOpacity
@@ -66,7 +111,7 @@ export default function SettingContent() {
             className={`flex-row items-center justify-between border-b border-gray-200 px-4 py-3.5 ${
               index === appInfoMenus.length - 1 ? 'border-b-0' : ''
             }`}
-            onPress={() => console.log(`${menu.title} 클릭`)}
+            onPress={() => handleMenuPress(menu.id)}
           >
             <Text className="text-base text-gray-800">{menu.title}</Text>
             <Feather name="chevron-right" size={22} color="#A0A0A0" />

--- a/src/components/ui/InAppBrowser/InAppBrowser.tsx
+++ b/src/components/ui/InAppBrowser/InAppBrowser.tsx
@@ -12,6 +12,7 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
+  Share,
 } from 'react-native'
 import { WebView } from 'react-native-webview'
 
@@ -73,8 +74,8 @@ export default function InAppBrowser({
     try {
       await Clipboard.setStringAsync(url)
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
-      setShowActionSheet(false)
       Alert.alert('링크 복사 완료', '클립보드에 복사되었습니다.')
+      setShowActionSheet(false)
     } catch {
       Alert.alert('오류', '링크 복사에 실패했습니다.')
     }
@@ -84,12 +85,20 @@ export default function InAppBrowser({
   const handleOpenInBrowser = useCallback(async () => {
     if (!url) return
     try {
-      setShowActionSheet(false)
       await WebBrowser.openBrowserAsync(url)
+      setShowActionSheet(false)
     } catch {
       Alert.alert('오류', '브라우저를 열 수 없습니다.')
     }
   }, [url])
+
+  // 공유
+  const handleShare = useCallback(async () => {
+    await Share.share({
+      message: pageTitle,
+      url: url as string,
+    })
+  }, [url, pageTitle])
 
   // 파일 다운로드 처리
   const handleFileDownload = useCallback(
@@ -161,7 +170,6 @@ export default function InAppBrowser({
             <TouchableOpacity
               className="flex-1 pr-3"
               onPress={handleOpenActionSheet}
-              activeOpacity={0.7}
             >
               <Text
                 className="text-lg font-bold leading-tight text-gray-900"
@@ -177,7 +185,6 @@ export default function InAppBrowser({
             <TouchableOpacity
               onPress={onClose}
               className="ml-2 items-center justify-center"
-              activeOpacity={0.7}
             >
               <Ionicons name="close" size={30} color="#666" />
             </TouchableOpacity>
@@ -228,7 +235,6 @@ export default function InAppBrowser({
                   onPress={handleGoBack}
                   disabled={!canGoBack}
                   className="h-12 w-12 items-center justify-center rounded-lg"
-                  activeOpacity={0.7}
                 >
                   <Ionicons
                     name="chevron-back"
@@ -240,7 +246,6 @@ export default function InAppBrowser({
                   onPress={handleGoForward}
                   disabled={!canGoForward}
                   className="h-12 w-12 items-center justify-center rounded-lg"
-                  activeOpacity={0.7}
                 >
                   <Ionicons
                     name="chevron-forward"
@@ -249,13 +254,20 @@ export default function InAppBrowser({
                   />
                 </TouchableOpacity>
               </View>
-              <TouchableOpacity
-                onPress={handleReload}
-                className="h-12 w-12 items-center justify-center rounded-lg"
-                activeOpacity={0.7}
-              >
-                <Ionicons name="reload" size={24} color="#333" />
-              </TouchableOpacity>
+              <View className="flex-row items-center gap-4">
+                <TouchableOpacity
+                  onPress={handleShare}
+                  className="h-12 w-12 items-center justify-center rounded-lg"
+                >
+                  <Ionicons name="share-outline" size={24} color="#333" />
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={handleReload}
+                  className="h-12 w-12 items-center justify-center rounded-lg"
+                >
+                  <Ionicons name="reload" size={24} color="#333" />
+                </TouchableOpacity>
+              </View>
             </View>
           </Animated.View>
         </View>
@@ -265,14 +277,10 @@ export default function InAppBrowser({
           <View className="absolute inset-0 z-50">
             <TouchableOpacity
               className="flex-1 bg-black/50"
-              activeOpacity={1}
               onPress={() => setShowActionSheet(false)}
             >
               <View className="flex-1 justify-end">
-                <TouchableOpacity
-                  activeOpacity={1}
-                  onPress={(e) => e.stopPropagation()}
-                >
+                <TouchableOpacity onPress={(e) => e.stopPropagation()}>
                   <View className="rounded-t-3xl bg-white pb-8 pt-4">
                     <View className="mb-4 items-center">
                       <View className="h-1 w-10 rounded-full bg-gray-300" />
@@ -280,8 +288,23 @@ export default function InAppBrowser({
 
                     <TouchableOpacity
                       className="flex-row items-center px-6 py-4"
+                      onPress={handleShare}
+                    >
+                      <View className="mr-4 h-10 w-10 items-center justify-center rounded-full bg-blue-50">
+                        <Ionicons
+                          name="share-outline"
+                          size={20}
+                          color="#0158a6"
+                        />
+                      </View>
+                      <Text className="text-base font-medium text-gray-900">
+                        공유
+                      </Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                      className="flex-row items-center px-6 py-4"
                       onPress={handleCopyLink}
-                      activeOpacity={0.7}
                     >
                       <View className="mr-4 h-10 w-10 items-center justify-center rounded-full bg-blue-50">
                         <Ionicons
@@ -298,7 +321,6 @@ export default function InAppBrowser({
                     <TouchableOpacity
                       className="flex-row items-center px-6 py-4"
                       onPress={handleOpenInBrowser}
-                      activeOpacity={0.7}
                     >
                       <View className="mr-4 h-10 w-10 items-center justify-center rounded-full bg-blue-50">
                         <Ionicons

--- a/src/components/ui/InAppBrowser/InAppBrowser.tsx
+++ b/src/components/ui/InAppBrowser/InAppBrowser.tsx
@@ -1,0 +1,323 @@
+import React, { useState, useRef, useCallback } from 'react'
+
+import { Ionicons } from '@expo/vector-icons'
+import * as Clipboard from 'expo-clipboard'
+import * as Haptics from 'expo-haptics'
+import * as WebBrowser from 'expo-web-browser'
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Animated,
+} from 'react-native'
+import { WebView } from 'react-native-webview'
+
+interface InAppBrowserProps {
+  visible: boolean
+  url: string | null
+  onClose: () => void
+}
+
+export default function InAppBrowser({
+  visible,
+  url,
+  onClose,
+}: InAppBrowserProps) {
+  const webViewRef = useRef<WebView>(null)
+  const [canGoBack, setCanGoBack] = useState(false)
+  const [canGoForward, setCanGoForward] = useState(false)
+  const [pageTitle, setPageTitle] = useState('')
+  const [showActionSheet, setShowActionSheet] = useState(false)
+
+  // 스크롤 관련 상태
+  const scrollY = useRef(0)
+  const footerTranslateY = useRef(new Animated.Value(0)).current
+  const lastScrollY = useRef(0)
+
+  // 액션 시트
+  const handleOpenActionSheet = useCallback(() => {
+    setShowActionSheet(true)
+  }, [])
+
+  // 호스트 이름
+  const getHostname = useCallback(() => {
+    if (!url) return '웹페이지'
+    try {
+      return new URL(url).hostname
+    } catch {
+      return '웹페이지'
+    }
+  }, [url])
+
+  // 뒤로가기
+  const handleGoBack = useCallback(() => {
+    if (canGoBack && webViewRef.current) webViewRef.current.goBack()
+  }, [canGoBack])
+
+  // 앞으로가기
+  const handleGoForward = useCallback(() => {
+    if (canGoForward && webViewRef.current) webViewRef.current.goForward()
+  }, [canGoForward])
+
+  // 새로고침
+  const handleReload = useCallback(() => {
+    webViewRef.current?.reload()
+  }, [])
+
+  // 링크 복사
+  const handleCopyLink = useCallback(async () => {
+    if (!url) return
+    try {
+      await Clipboard.setStringAsync(url)
+      Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success)
+      setShowActionSheet(false)
+      Alert.alert('링크 복사 완료', '클립보드에 복사되었습니다.')
+    } catch {
+      Alert.alert('오류', '링크 복사에 실패했습니다.')
+    }
+  }, [url])
+
+  // 외부 브라우저
+  const handleOpenInBrowser = useCallback(async () => {
+    if (!url) return
+    try {
+      setShowActionSheet(false)
+      await WebBrowser.openBrowserAsync(url)
+    } catch {
+      Alert.alert('오류', '브라우저를 열 수 없습니다.')
+    }
+  }, [url])
+
+  // 파일 다운로드 처리
+  const handleFileDownload = useCallback(
+    ({ nativeEvent }: { nativeEvent: { downloadUrl: string } }) => {
+      const downloadUrl = nativeEvent.downloadUrl
+      if (downloadUrl) {
+        WebBrowser.openBrowserAsync(downloadUrl)
+      }
+    },
+    []
+  )
+
+  // 스크롤 메시지
+  const handleMessage = useCallback(
+    (event: { nativeEvent: { data: string } }) => {
+      try {
+        const data = JSON.parse(event.nativeEvent.data)
+        if (data.type === 'scroll') {
+          const currentScrollY = data.scrollY
+          const scrollDiff = currentScrollY - lastScrollY.current
+          if (Math.abs(scrollDiff) > 10) {
+            if (scrollDiff > 0 && currentScrollY > 150) {
+              Animated.timing(footerTranslateY, {
+                toValue: 100,
+                duration: 200,
+                useNativeDriver: true,
+              }).start()
+            } else if (scrollDiff < 0) {
+              Animated.timing(footerTranslateY, {
+                toValue: 0,
+                duration: 200,
+                useNativeDriver: true,
+              }).start()
+            }
+            lastScrollY.current = currentScrollY
+          }
+          scrollY.current = currentScrollY
+        }
+      } catch {}
+    },
+    [footerTranslateY]
+  )
+
+  // WebView에 주입할 JS
+  const injectedJavaScript = `
+    let lastScrollY = 0;
+    let ticking = false;
+    window.addEventListener('scroll', function() {
+      if (!ticking) {
+        window.requestAnimationFrame(function() {
+          const scrollY = window.pageYOffset || document.documentElement.scrollTop;
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'scroll', scrollY }));
+          ticking = false;
+        });
+        ticking = true;
+      }
+    });
+    true;
+  `
+
+  if (!url) return null
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+      <View className="flex-1 bg-white">
+        {/* 헤더 */}
+        <View className="border-b border-gray-100 bg-white px-4 pb-3 pt-20">
+          <View className="flex-row items-center justify-between">
+            <TouchableOpacity
+              className="flex-1 pr-3"
+              onPress={handleOpenActionSheet}
+              activeOpacity={0.7}
+            >
+              <Text
+                className="text-lg font-bold leading-tight text-gray-900"
+                numberOfLines={1}
+              >
+                {pageTitle || getHostname()}
+              </Text>
+              <Text className="mt-1 text-xs text-gray-400" numberOfLines={1}>
+                {getHostname()}
+              </Text>
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={onClose}
+              className="ml-2 items-center justify-center"
+              activeOpacity={0.7}
+            >
+              <Ionicons name="close" size={30} color="#666" />
+            </TouchableOpacity>
+          </View>
+        </View>
+
+        {/* 웹뷰 */}
+        <View className="flex-1">
+          <WebView
+            ref={webViewRef}
+            source={{ uri: url }}
+            style={{ flex: 1 }}
+            javaScriptEnabled
+            domStorageEnabled
+            allowFileAccess
+            mixedContentMode="compatibility"
+            originWhitelist={['*']}
+            onFileDownload={handleFileDownload}
+            onNavigationStateChange={(navState) => {
+              setCanGoBack(navState.canGoBack)
+              setCanGoForward(navState.canGoForward)
+              setPageTitle(navState.title || '')
+            }}
+            onMessage={handleMessage}
+            injectedJavaScript={injectedJavaScript}
+            startInLoadingState
+            renderLoading={() => (
+              <View className="absolute inset-0 items-center justify-center bg-white">
+                <ActivityIndicator size="large" color="#0158a6" />
+              </View>
+            )}
+          />
+
+          {/* 푸터 */}
+          <Animated.View
+            style={{
+              position: 'absolute',
+              bottom: 0,
+              left: 0,
+              right: 0,
+              transform: [{ translateY: footerTranslateY }],
+            }}
+            className="border-t border-gray-100 bg-white px-4 pb-8 pt-2"
+          >
+            <View className="flex-row items-center justify-between">
+              <View className="flex-row items-center gap-2">
+                <TouchableOpacity
+                  onPress={handleGoBack}
+                  disabled={!canGoBack}
+                  className="h-12 w-12 items-center justify-center rounded-lg"
+                  activeOpacity={0.7}
+                >
+                  <Ionicons
+                    name="chevron-back"
+                    size={26}
+                    color={canGoBack ? '#333' : '#d1d5db'}
+                  />
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={handleGoForward}
+                  disabled={!canGoForward}
+                  className="h-12 w-12 items-center justify-center rounded-lg"
+                  activeOpacity={0.7}
+                >
+                  <Ionicons
+                    name="chevron-forward"
+                    size={26}
+                    color={canGoForward ? '#333' : '#d1d5db'}
+                  />
+                </TouchableOpacity>
+              </View>
+              <TouchableOpacity
+                onPress={handleReload}
+                className="h-12 w-12 items-center justify-center rounded-lg"
+                activeOpacity={0.7}
+              >
+                <Ionicons name="reload" size={24} color="#333" />
+              </TouchableOpacity>
+            </View>
+          </Animated.View>
+        </View>
+
+        {/* 액션 시트 */}
+        {showActionSheet && (
+          <View className="absolute inset-0 z-50">
+            <TouchableOpacity
+              className="flex-1 bg-black/50"
+              activeOpacity={1}
+              onPress={() => setShowActionSheet(false)}
+            >
+              <View className="flex-1 justify-end">
+                <TouchableOpacity
+                  activeOpacity={1}
+                  onPress={(e) => e.stopPropagation()}
+                >
+                  <View className="rounded-t-3xl bg-white pb-8 pt-4">
+                    <View className="mb-4 items-center">
+                      <View className="h-1 w-10 rounded-full bg-gray-300" />
+                    </View>
+
+                    <TouchableOpacity
+                      className="flex-row items-center px-6 py-4"
+                      onPress={handleCopyLink}
+                      activeOpacity={0.7}
+                    >
+                      <View className="mr-4 h-10 w-10 items-center justify-center rounded-full bg-blue-50">
+                        <Ionicons
+                          name="copy-outline"
+                          size={20}
+                          color="#0158a6"
+                        />
+                      </View>
+                      <Text className="text-base font-medium text-gray-900">
+                        링크 복사
+                      </Text>
+                    </TouchableOpacity>
+
+                    <TouchableOpacity
+                      className="flex-row items-center px-6 py-4"
+                      onPress={handleOpenInBrowser}
+                      activeOpacity={0.7}
+                    >
+                      <View className="mr-4 h-10 w-10 items-center justify-center rounded-full bg-blue-50">
+                        <Ionicons
+                          name="open-outline"
+                          size={20}
+                          color="#0158a6"
+                        />
+                      </View>
+                      <Text className="text-base font-medium text-gray-900">
+                        외부 브라우저에서 열기
+                      </Text>
+                    </TouchableOpacity>
+                  </View>
+                </TouchableOpacity>
+              </View>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+    </Modal>
+  )
+}

--- a/src/components/util/UtilContent/UtilContent.tsx
+++ b/src/components/util/UtilContent/UtilContent.tsx
@@ -38,7 +38,7 @@ export const UtilContent = () => {
     }
   }
 
-  //
+  // useFocusEffect를 사용하여 화면이 포커스될 때마다 인기 공지사항을 로드합니다.
   useFocusEffect(
     useCallback(() => {
       const fetchPopularPosts = async () => {
@@ -66,8 +66,6 @@ export const UtilContent = () => {
         } catch (err) {
           console.error('인기 게시글 로드 실패:', err)
           setError('게시글을 불러오는 데 실패했습니다.')
-
-          // [!!] 여기서 콘솔에 뜨는 "색인" 관련 에러를 꼭 확인하세요!
         } finally {
           setIsLoading(false)
         }
@@ -100,7 +98,7 @@ export const UtilContent = () => {
                   <View className="mt-2.5 flex-row items-center justify-between">
                     <View className="flex-1 flex-row items-center gap-1.5">
                       {/* 학과 */}
-                      <Text className="text-xs font-medium text-blue-600">
+                      <Text className="text-xs font-medium text-deu-light-blue">
                         {item.department}
                       </Text>
                       <Text className="text-xs text-gray-400">|</Text>

--- a/src/components/util/UtilContent/UtilContent.tsx
+++ b/src/components/util/UtilContent/UtilContent.tsx
@@ -1,144 +1,156 @@
+import { useState } from 'react'
+
 import { MaterialIcons } from '@expo/vector-icons'
 import { View, Text, TouchableOpacity, ScrollView } from 'react-native'
 
+import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
+import { quickItem, uniPlan, uniPlanUrl } from '@/constants/utilContent'
 import { calculateDDay } from '@/utils/dDay'
 
 export const UtilContent = () => {
-  const quickItem = [
+  const popularPost = [
     {
       id: 1,
-      title: '동의대학교',
-      icon: '🏫',
-      link: '/util/quick',
-    },
-    {
-      id: 2,
-      title: 'DAP',
-      icon: '💻',
-      link: '/util/dap',
-    },
-    {
-      id: 3,
-      title: 'DOOR',
-      icon: '🚪',
-      link: '/util/door',
+      title: '동의대학교 홈',
+      department: '컴퓨터공학과',
+      tags: ['#기타'],
+      savedAt: '2025-01-01',
+      ScrapCount: 10,
     },
   ]
 
-  const uniPlan = [
-    {
-      id: 1,
-      title: '수강신청 변경 기간',
-      date: '10/10 ~ 10/11',
-    },
-    {
-      id: 2,
-      title: '2학기 중간고사',
-      date: '10/20 ~ 10/25',
-    },
-    {
-      id: 3,
-      title: '개교 기념일',
-      date: '10/26',
-    },
-  ]
+  // 인앱 브라우저 상태
+  const [browserVisible, setBrowserVisible] = useState(false)
+  const [browserUrl, setBrowserUrl] = useState<string | null>(null)
 
-  const campusUtil = [
-    {
-      id: 1,
-      icon: 'location-pin',
-      title: '캠퍼스 맵',
-    },
-    {
-      id: 2,
-      icon: 'restaurant-menu',
-      title: '오늘의 학식',
-    },
-  ]
-
+  // 링크 열기
+  const handleOpenLink = (link: string) => {
+    if (link) {
+      setBrowserUrl(link)
+      setBrowserVisible(true)
+    }
+  }
   return (
-    <ScrollView>
-      <View className="gap-6 bg-gray-50 px-4 py-4">
-        {/* 빠른 바로가기 */}
-        <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
-          <Text className="mb-5 text-lg font-semibold">빠른 바로가기</Text>
-          <View className="flex-row justify-around gap-4">
-            {quickItem.map((item) => (
-              <TouchableOpacity
-                key={item.id}
-                className="w-[100px] items-center gap-2 rounded-xl border border-gray-100 px-3 py-3"
-              >
-                <Text>{item.icon}</Text>
-                <Text>{item.title}</Text>
-              </TouchableOpacity>
-            ))}
+    <>
+      <ScrollView>
+        <View className="gap-6 bg-gray-50 px-4 py-4">
+          {/* 인기 공지사항 */}
+          <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
+            <Text className="mb-5 text-lg font-semibold">인기 게시글</Text>
+            <View className="flex-col gap-4">
+              {popularPost.map((item) => (
+                <TouchableOpacity
+                  key={item.id}
+                  className="w-full flex-row items-center gap-4 rounded-xl border border-gray-100 px-4 py-3"
+                >
+                  <Text className="text-base font-medium">{item.title}</Text>
+                  <Text className="text-sm text-gray-500">
+                    {item.department}
+                  </Text>
+                  <Text className="text-sm text-gray-500">
+                    {item.tags.join(', ')}
+                  </Text>
+                  <Text className="text-sm text-gray-500">{item.savedAt}</Text>
+                  <Text className="text-sm text-gray-500">
+                    {item.ScrapCount}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
           </View>
-        </View>
 
-        {/* 학사 일정 */}
-        <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
-          <View className="flex-row justify-between">
-            <Text className="mb-5 text-center text-lg font-semibold">
-              잊지마세요! 주요 학사일정
-            </Text>
-            <MaterialIcons name="calendar-today" size={18} color="black" />
-          </View>
-          <View className="gap-3">
-            {uniPlan.map((plan) => (
-              <View
-                key={plan.id}
-                className="w-full rounded-xl bg-gray-50 px-2.5 py-2"
-              >
-                <View className="flex-row justify-between">
-                  <View>
-                    <Text className="text-base font-medium">{plan.title}</Text>
-                    <Text className="text-sm text-gray-500">{plan.date}</Text>
-                  </View>
-                  <View className="justify-center">
-                    {(() => {
-                      const { text, textColor, bgColor } = calculateDDay(
-                        plan.date
-                      )
-                      return (
+          {/* 학사 일정 */}
+          <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
+            <View className="flex-row justify-between">
+              <Text className="mb-5 text-center text-lg font-semibold">
+                잊지마세요! 주요 학사일정
+              </Text>
+              <MaterialIcons name="calendar-today" size={18} color="black" />
+            </View>
+            <View className="gap-3">
+              {uniPlan
+                .map((plan) => ({
+                  ...plan,
+                  dday: calculateDDay(plan.date),
+                }))
+                .filter((plan) => {
+                  // D-Day 또는 D-로 시작하는 항목만 필터링
+                  return (
+                    plan.dday.text === 'D-Day' ||
+                    plan.dday.text.startsWith('D-')
+                  )
+                })
+                .slice(0, 3)
+                .map((plan) => (
+                  <View
+                    key={plan.id}
+                    className="w-full rounded-xl bg-gray-50 px-2.5 py-2"
+                  >
+                    <View className="flex-row justify-between">
+                      <View>
+                        <Text className="text-base font-medium">
+                          {plan.title}
+                        </Text>
+                        <Text className="text-sm text-gray-500">
+                          {plan.date}
+                        </Text>
+                      </View>
+                      <View className="justify-center">
                         <View
-                          className={`justify-center rounded-lg ${bgColor} px-1.5 py-0.5`}
+                          className={`justify-center rounded-lg ${plan.dday.bgColor} px-1.5 py-0.5`}
                         >
-                          <Text className={`text-sm font-medium ${textColor}`}>
-                            {text}
+                          <Text
+                            className={`text-sm font-medium ${plan.dday.textColor}`}
+                          >
+                            {plan.dday.text}
                           </Text>
                         </View>
-                      )
-                    })()}
+                      </View>
+                    </View>
                   </View>
-                </View>
-              </View>
-            ))}
-            <TouchableOpacity className="w-full items-center justify-center rounded-xl border border-gray-100 px-4 py-3">
-              <Text className="text-base font-medium">전체 학사일정 보기</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-
-        {/* 편의 기능 */}
-        <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
-          <Text className="mb-5 text-lg font-semibold">편의 기능</Text>
-          <View className="flex-col gap-4">
-            {campusUtil.map((item) => (
+                ))}
               <TouchableOpacity
-                key={item.id}
-                className="w-full flex-row items-center gap-4 rounded-xl border border-gray-100 px-4 py-3"
+                className="w-full items-center justify-center rounded-xl border border-gray-100 px-4 py-3"
+                onPress={() => handleOpenLink(uniPlanUrl)}
               >
-                <MaterialIcons
-                  name={item.icon as keyof typeof MaterialIcons.glyphMap}
-                  size={18}
-                  color="black"
-                />
-                <Text className="text-base font-medium">{item.title}</Text>
+                <Text className="text-base font-medium">
+                  전체 학사일정 보기
+                </Text>
               </TouchableOpacity>
-            ))}
+            </View>
+          </View>
+
+          {/* 빠른 바로가기 */}
+          <View className="rounded-xl border border-gray-100 bg-white px-4 py-4">
+            <Text className="mb-5 text-lg font-semibold">빠른 바로가기</Text>
+            <View className="flex-row flex-wrap justify-center gap-3">
+              {quickItem.map((item) => (
+                <TouchableOpacity
+                  key={item.id}
+                  className="w-[30%] items-center gap-3 rounded-2xl border border-gray-100 bg-gray-50 px-3 py-4 transition-all active:scale-95 active:bg-gray-100"
+                  onPress={() => handleOpenLink(item.link)}
+                >
+                  <View className="rounded-full bg-white p-3 shadow-sm">
+                    <MaterialIcons
+                      name={item.icon as keyof typeof MaterialIcons.glyphMap}
+                      size={24}
+                      color="#3B82F6"
+                    />
+                  </View>
+                  <Text className="text-center text-sm font-medium text-gray-700">
+                    {item.title}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
           </View>
         </View>
-      </View>
-    </ScrollView>
+      </ScrollView>
+      <InAppBrowser
+        visible={browserVisible}
+        url={browserUrl}
+        onClose={() => setBrowserVisible(false)}
+      />
+    </>
   )
 }

--- a/src/constants/utilContent.ts
+++ b/src/constants/utilContent.ts
@@ -1,0 +1,143 @@
+export const quickItem = [
+  {
+    id: 1,
+    title: '동의대학교 홈',
+    icon: 'home',
+    link: 'https://dap.deu.ac.kr/',
+  },
+  {
+    id: 2,
+    title: 'DAP',
+    icon: 'school',
+    link: 'https://dap.deu.ac.kr/',
+  },
+  {
+    id: 3,
+    title: 'DOOR',
+    icon: 'door-front',
+    link: 'https://door.deu.ac.kr/',
+  },
+  {
+    id: 4,
+    title: '중앙 도서관',
+    icon: 'local-library',
+    link: 'https://lib.deu.ac.kr/',
+  },
+  {
+    id: 5,
+    title: '생활관',
+    icon: 'apartment',
+    link: 'https://dorm.deu.ac.kr',
+  },
+  {
+    id: 6,
+    title: '통학버스',
+    icon: 'directions-bus',
+    link: 'https://www.deu.ac.kr/www/deu-sbus.do',
+  },
+]
+
+export const uniPlanUrl = 'https://www.deu.ac.kr/www/scheduleList.do'
+
+export const uniPlan = [
+  {
+    id: 1,
+    title: '개교기념일',
+    date: '10/22',
+  },
+  {
+    id: 2,
+    title: '중간시험',
+    date: '10/27 ~ 10/31',
+  },
+  {
+    id: 3,
+    title: '수업일수 1/2선',
+    date: '10/29',
+  },
+  {
+    id: 4,
+    title: '학기경과일수 60일째',
+    date: '10/30',
+  },
+  {
+    id: 5,
+    title: '수업일수 2/3선',
+    date: '11/17',
+  },
+  {
+    id: 6,
+    title: '수업일수 3/4선',
+    date: '11/25',
+  },
+  {
+    id: 7,
+    title: '학기경과일수 90일째',
+    date: '11/29',
+  },
+  {
+    id: 8,
+    title: '지정보강일 (10.6/10.7 추석)',
+    date: '12/8 ~ 12/9',
+  },
+  {
+    id: 9,
+    title: '지정보강일 (10.8 대체공휴일)',
+    date: '12/10',
+  },
+  {
+    id: 10,
+    title: '지정보강일 (10.9 한글날)',
+    date: '12/11',
+  },
+  {
+    id: 11,
+    title: '지정보강일 (10.3 개천절)',
+    date: '12/12',
+  },
+  {
+    id: 12,
+    title: '지정보강일 (10.10 임시공휴일)',
+    date: '12/15',
+  },
+  {
+    id: 13,
+    title: '기말시험',
+    date: '12/16 ~ 12/22',
+  },
+  {
+    id: 14,
+    title: '동계방학 시작일',
+    date: '12/23',
+  },
+  {
+    id: 15,
+    title: '성탄절',
+    date: '12/25',
+  },
+  {
+    id: 16,
+    title: '동계계절수업',
+    date: '12/29 ~ 1/19',
+  },
+  {
+    id: 17,
+    title: '신정',
+    date: '1/1',
+  },
+  {
+    id: 18,
+    title: '설날',
+    date: '2/16 ~ 2/18',
+  },
+  {
+    id: 19,
+    title: '현금등록, 수강신청',
+    date: '2/19 ~ 2/24',
+  },
+  {
+    id: 20,
+    title: '2025학년도 전기 학위 수여식',
+    date: '2/20',
+  },
+]

--- a/src/hooks/useFetchNotices.ts
+++ b/src/hooks/useFetchNotices.ts
@@ -68,8 +68,8 @@ export const useFetchNotices = (limitCount = 20) => {
   const { selectedCategory } = useCategoryFilterStore()
 
   return useQuery({
-    // 쿼리 키: 카테고리가 변경될 때마다 다른 쿼리로 인식
-    queryKey: ['notices', selectedCategory || undefined, limitCount],
+    // 쿼리 키: 카테고리가 변경될 때마다 다른 쿼리로 인식 (limitCount 제거로 cacheManager와 통일)
+    queryKey: ['notices', selectedCategory || undefined],
 
     // 실제 데이터를 가져오는 함수
     queryFn: async () => {
@@ -81,13 +81,13 @@ export const useFetchNotices = (limitCount = 20) => {
       return result
     },
 
-    // 캐시 설정: 5분간 fresh 상태 유지 (이 시간 동안은 Firestore 호출 안 함)
-    staleTime: 5 * 60 * 1000, // 5분
+    // 캐시 설정
+    staleTime: 10 * 60 * 1000, // 10분
 
-    // 가비지 컬렉션 시간: 10분간 메모리에 캐시 유지
-    gcTime: 10 * 60 * 1000, // 10분
+    // 가비지 컬렉션 시간
+    gcTime: 30 * 60 * 1000, // 30분
 
-    // 선택된 카테고리가 변경될 때만 리페치
+    // 캐시가 있으면 사용 (queryClient 설정과 통일)
     refetchOnMount: false,
 
     // 앱 포커스 시 리페치 방지 (배터리 절약)

--- a/src/hooks/useNotificationSettings.ts
+++ b/src/hooks/useNotificationSettings.ts
@@ -14,7 +14,7 @@ import { useNotificationStore } from '@/store/notificationStore'
  * 알림 설정 관련 비즈니스 로직을 관리하는 커스텀 훅
  */
 export function useNotificationSettings() {
-  const { getPushToken } = usePushNotifications()
+  const { getPushToken, handleToggleNotification } = usePushNotifications()
 
   const {
     selectedKeywords: selectedKeywordsArray,
@@ -142,6 +142,14 @@ export function useNotificationSettings() {
     setSelectedDepartment(null)
   }, [setSelectedDepartment])
 
+  // 알림 토글 핸들러 (푸시 권한 요청 포함)
+  const handleNotificationToggle = useCallback(
+    (value: boolean) => {
+      handleToggleNotification(value, setNotificationEnabled)
+    },
+    [handleToggleNotification, setNotificationEnabled]
+  )
+
   return {
     // 상태
     selectedKeywords,
@@ -151,7 +159,7 @@ export function useNotificationSettings() {
     notificationEnabled,
 
     // 액션
-    setNotificationEnabled,
+    handleNotificationToggle,
     handleKeywordUpdate,
     handleDepartmentUpdate,
     handleKeywordRemove,

--- a/src/hooks/usePushNotifications.ts
+++ b/src/hooks/usePushNotifications.ts
@@ -27,7 +27,7 @@ export function usePushNotifications() {
       if (finalStatus !== 'granted') {
         Alert.alert(
           '알림 권한 필요',
-          '설정에서 알림 권한을 허용해야 푸시를 받을 수 있어요.',
+          '설정에서 알림 권한을 허용해야 알림을 받을 수 있어요.',
           [
             { text: '취소', style: 'cancel' },
             {
@@ -51,6 +51,7 @@ export function usePushNotifications() {
       }
 
       return true
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (e) {
       Alert.alert('오류', '푸시 권한 요청 중 문제가 발생했어요.')
       return false

--- a/src/utils/cacheManager.ts
+++ b/src/utils/cacheManager.ts
@@ -61,13 +61,13 @@ export const useCacheManager = () => {
           q = query(
             noticesCollectionRef,
             where('department', '==', category),
-            orderBy('created_at', 'desc'),
+            orderBy('saved_at', 'desc'),
             limit(limitCount)
           )
         } else {
           q = query(
             noticesCollectionRef,
-            orderBy('created_at', 'desc'),
+            orderBy('saved_at', 'desc'),
             limit(limitCount)
           )
         }
@@ -78,7 +78,7 @@ export const useCacheManager = () => {
           ...doc.data(),
         })) as Notice[]
       },
-      staleTime: 5 * 60 * 1000,
+      staleTime: 10 * 60 * 1000,
     })
   }
 

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -4,29 +4,29 @@ import { QueryClient } from '@tanstack/react-query'
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // 데이터가 fresh 상태로 유지되는 시간 (5분)
-      staleTime: 5 * 60 * 1000,
+      // 데이터가 fresh 상태로 유지되는 시간
+      staleTime: 10 * 60 * 1000,
 
-      // 캐시가 메모리에 유지되는 시간 (10분)
-      gcTime: 10 * 60 * 1000,
+      // 캐시가 메모리에 유지되는 시간
+      gcTime: 30 * 60 * 1000,
 
       // 재시도 설정
       retry: (failureCount, error) => {
         // 네트워크 에러의 경우만 재시도
         if (error?.message?.includes('network')) {
-          return failureCount < 3
+          return failureCount < 2 // 재시도 횟수 줄임
         }
         return false
       },
+
+      // 캐시가 있으면 사용, 없으면 요청 (불필요한 재요청 방지)
+      refetchOnMount: false,
 
       // 앱 포커스 시 리페치 방지 (배터리 절약)
       refetchOnWindowFocus: false,
 
       // 앱 백그라운드에서 돌아올 때 리페치 방지
       refetchOnReconnect: false,
-
-      // 마운트 시 중복 요청 방지
-      refetchOnMount: true,
     },
     mutations: {
       // 뮤테이션 실패 시 재시도


### PR DESCRIPTION
## 📝설명
해당 PR은 유틸 페이지의 기능 개발(인기 공지사항, 학사일정, 빠른 바로가기)을 목표로합니다.
또한 이전 `WebBowser.openBrowserAsync`로 열었던 외부 인앱 브라우저를 커스텀 WebView로 개선합니다.


### 📍개발 범위
**WebView 개선**
- 상단 헤더: 제목, 링크, 닫기 버튼
- 하단 푸터: 이전/다음, 공유, 새로고침 버튼
<img width="327" height="679" alt="1" src="https://github.com/user-attachments/assets/4a6e8694-5b06-4704-b3d7-594c97833653" />

**useFetchNotices 훅 캐싱 조정**
- staleTime: 10분
- gcTime: 30분
- refetchOnMount: false (캐시가 있으면 재사용, 없으면 요청)

**Drawer 제스처 제한**
- 홈 탭에서만 Drawer swipe 허용 (swipeEnabled: false → 홈 탭에서만 true)

**Util 페이지 UI 개선**
- 인기 공지사항 Top 3
  - ScrapCount 10 이상일 때 인기 공지
  - 유저가 스크랩하면 낙관적 업데이트 후 서버 반영
- 학사일정
   - 2026년 2월 이후까지 하드코딩, 최대 3개 표시
  - 전체 학사일정은 외부 웹뷰 연결
- 빠른 바로가기
  - 동의대학교 홈, DAP, DOOR, 중앙 도서관, 생활관, 통학버스
<img width="668" height="591" alt="2" src="https://github.com/user-attachments/assets/bf68de47-a005-4fbc-b5e8-98c4f1503199" />

**Scrap Count 처리 방식**
- 낙관적 업데이트 적용
  - updateDoc(docRef, { scrap_count: increment(1 or -1) }) 사용,  전위/후위 연산 대신 increment() 사용 → 유저별 동시 업데이트 충돌 방지

**Setting 페이지 앱 약관 및 기능**
- 앱지원
  - 알림 설정
  - 건의하기(Firestore 저장)
- 앱 정보
  - 이용 약관
  - 개인정보 처리방침
  - 오픈소스 라이선스
