### PR TITLE
feat: algolia-notices-migration

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -66,6 +66,10 @@ const config: ExpoConfig = {
       process.env.EXPO_PUBLIC_ANDROID_BANNER_AD_UNIT,
     EXPO_PUBLIC_ANDROID_INTERSTITIAL_AD_UNIT:
       process.env.EXPO_PUBLIC_ANDROID_INTERSTITIAL_AD_UNIT,
+    EXPO_PUBLIC_ALGOLIA_APPLICATION_ID:
+      process.env.EXPO_PUBLIC_ALGOLIA_APPLICATION_ID,
+    EXPO_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY:
+      process.env.EXPO_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY,
     router: {},
     eas: {
       projectId: 'e0b0a38e-f8a6-44b6-a6be-270eaaff6f7a',

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -40,16 +40,24 @@ export default function HomeScreen() {
   const listData = useMemo<ListItem[]>(() => {
     const notices = data?.pages.flatMap((page) => page.notices) || []
 
+    // content_hash 기준 중복 제거
+    const seen = new Set<string>()
+    const deduped = notices.filter((n) => {
+      const id = n.content_hash
+      if (seen.has(id)) return false
+      seen.add(id)
+      return true
+    })
+
     const result: ListItem[] = []
     const adInterval = 7 // 7개마다 광고
+    let adCount = 0
 
-    notices.forEach((notice, index) => {
-      // 7개마다 광고 삽입
+    deduped.forEach((notice, index) => {
       if (index !== 0 && index % adInterval === 0) {
-        result.push({ type: 'ad', id: `ad-${index}` })
+        adCount += 1
+        result.push({ type: 'ad', id: `ad-${adCount}` })
       }
-
-      // 공지사항 삽입
       result.push({ type: 'notice', data: notice })
     })
 

--- a/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
+++ b/src/components/notification/NotificaitonItem/NotificaitonItem.tsx
@@ -97,6 +97,17 @@ function NotificationItemContent({
 
   // 알림 탭: 브라우저 열고(있으면) 상위 onPress 호출
   const handlePress = () => {
+    // 읽음 처리만 위해 상위 onPress 호출, 브라우저는 열지 않음
+    if (!item.read) {
+      onPress?.({
+        id: item.id,
+        noticeLink: item.noticeLink,
+        noticeId: item.noticeId,
+      })
+      return
+    }
+
+    // 읽음이면 링크가 있을 때만 인앱 브라우저 오픈 후 상위 onPress
     if (item.noticeLink) {
       setBrowserUrl(item.noticeLink)
       setBrowserVisible(true)

--- a/src/config/algoliaConfig.ts
+++ b/src/config/algoliaConfig.ts
@@ -1,10 +1,12 @@
 import { algoliasearch } from 'algoliasearch'
 
-// Algolia API 키들
-const ALGOLIA_APPLICATION_ID = process.env
-  .EXPO_PUBLIC_ALGOLIA_APPLICATION_KEY as string
-const ALGOLIA_SEARCH_ONLY_API_KEY = process.env
-  .EXPO_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY as string
+const ALGOLIA_APPLICATION_ID = process.env.EXPO_PUBLIC_ALGOLIA_APPLICATION_ID
+const ALGOLIA_SEARCH_ONLY_API_KEY =
+  process.env.EXPO_PUBLIC_ALGOLIA_SEARCH_ONLY_API_KEY
+
+if (!ALGOLIA_APPLICATION_ID || !ALGOLIA_SEARCH_ONLY_API_KEY) {
+  throw new Error('Algolia 환경변수가 존재하지 않습니다.')
+}
 
 // Algolia 클라이언트 초기화
 export const searchClient = algoliasearch(

--- a/src/hooks/useFetchNotices.ts
+++ b/src/hooks/useFetchNotices.ts
@@ -1,134 +1,108 @@
 import { useInfiniteQuery } from '@tanstack/react-query'
-import {
-  collection,
-  getDocs,
-  query,
-  orderBy,
-  limit,
-  where,
-  startAfter,
-  DocumentData,
-} from 'firebase/firestore'
+import { Timestamp } from 'firebase/firestore'
 
-import { db } from '@/config/firebaseConfig'
+import {
+  NOTICES_INDEX,
+  searchClient,
+  searchConfig,
+} from '@/config/algoliaConfig'
 import { useCategoryFilterStore } from '@/store/categoryFilterStore'
 import { Notice } from '@/types/notice.type'
 
-// Firestore에서 공지사항 데이터를 가져오는 함수 (페이지네이션 지원)
-const fetchNoticesFromFirestore = async ({
-  pageParam,
-  category,
-  limitCount = 10,
-}: {
-  pageParam?: DocumentData
+// Algolia 히트 타입 정의
+type Hit = {
+  saved_at_ms?: number
+  saved_at?: string | number
+  published_at_ms?: number
+  published_at?: string | number
   category?: string
-  limitCount?: number
-}): Promise<{ notices: Notice[]; nextCursor?: DocumentData }> => {
-  const noticesCollectionRef = collection(db, 'notices')
-
-  // 선택된 카테고리가 있으면 필터링 조건과 함께 쿼리 구성
-  let q
-  if (category) {
-    // 카테고리 필터링 where + orderBy 조합
-    if (pageParam) {
-      // 다음 페이지인 경우 startAfter 사용
-      q = query(
-        noticesCollectionRef,
-        where('department', '==', category),
-        orderBy('saved_at', 'desc'),
-        startAfter(pageParam),
-        limit(limitCount)
-      )
-    } else {
-      // 첫 페이지인 경우
-      q = query(
-        noticesCollectionRef,
-        where('department', '==', category),
-        orderBy('saved_at', 'desc'),
-        limit(limitCount)
-      )
-    }
-  } else {
-    if (pageParam) {
-      // 다음 페이지인 경우 startAfter 사용
-      q = query(
-        noticesCollectionRef,
-        orderBy('saved_at', 'desc'),
-        startAfter(pageParam),
-        limit(limitCount)
-      )
-    } else {
-      // 첫 페이지인 경우
-      q = query(
-        noticesCollectionRef,
-        orderBy('saved_at', 'desc'),
-        limit(limitCount)
-      )
-    }
-  }
-
-  const querySnapshot = await getDocs(q)
-
-  // Firestore에서 가져온 데이터를 Notice[] 타입으로 변환합니다.
-  const notices = querySnapshot.docs.map((doc) => ({
-    ...doc.data(),
-    content_hash: doc.id, // 문서 ID를 content_hash로 사용 (고유성 보장)
-  })) as Notice[]
-
-  // 다음 페이지가 있는지 확인 (마지막 문서를 nextCursor로 반환)
-  const nextCursor =
-    querySnapshot.docs.length === limitCount
-      ? querySnapshot.docs[querySnapshot.docs.length - 1]
-      : undefined
-
-  return { notices, nextCursor }
+  content_hash?: string
+  objectID: string
+  department?: string
+  link?: string
+  scrap_count?: number
+  tags?: string[]
+  title?: string
 }
 
-/**
- * Firestore의 'notice' 컬렉션에서 공지사항 목록을 가져오는 커스텀 훅 (무한스크롤 지원)
- * 캐싱과 자동 리프레시 기능이 포함되어 Firestore 읽기 수를 대폭 줄임
- *
- * @param limitCount - 한 번에 가져올 공지사항 수 (기본값: 10)
- * @returns React Query의 useInfiniteQuery 결과 객체
- */
+// Algolia에서 공지사항 데이터를 가져오는 함수 (페이지네이션: page 기반)
+const fetchNoticesFromAlgolia = async ({
+  page = 0,
+  category,
+  hitsPerPage = 10,
+}: {
+  page?: number
+  category?: string
+  hitsPerPage?: number
+}): Promise<{ notices: Notice[]; nextPage?: number; nbPages: number }> => {
+  const filters = category ? `department:"${category}"` : undefined
+
+  const response = await searchClient.search({
+    requests: [
+      {
+        indexName: NOTICES_INDEX,
+        query: '',
+        page,
+        hitsPerPage,
+        filters,
+        attributesToRetrieve: searchConfig.attributesToRetrieve,
+      },
+    ],
+  })
+
+  const result = response.results[0] as unknown as {
+    hits: Hit[]
+    page: number
+    nbPages: number
+  }
+
+  const hits = Array.isArray(result?.hits) ? result.hits : []
+  const notices: Notice[] = hits.map((hit: Hit) => {
+    const savedAtVal =
+      hit.saved_at_ms ?? hit.saved_at ?? hit.published_at_ms ?? hit.published_at
+    const savedAtMs =
+      typeof savedAtVal === 'number'
+        ? savedAtVal
+        : new Date((savedAtVal as string | undefined) ?? 0).getTime()
+    return {
+      category: hit.category ?? '',
+      content_hash: hit.content_hash ?? hit.objectID,
+      department: hit.department ?? '',
+      link: hit.link ?? '',
+      saved_at: Timestamp.fromMillis(
+        Number.isFinite(savedAtMs) ? savedAtMs : Date.now()
+      ),
+      scrap_count: hit.scrap_count ?? 0,
+      tags: Array.isArray(hit.tags) ? hit.tags : [],
+      title: hit.title ?? '',
+    }
+  })
+
+  const nextPage =
+    result.page + 1 < result.nbPages ? result.page + 1 : undefined
+  return { notices, nextPage, nbPages: result.nbPages }
+}
+
 export const useFetchNotices = (limitCount = 10) => {
-  // 선택된 카테고리 상태 가져오기
   const { selectedCategory } = useCategoryFilterStore()
 
   return useInfiniteQuery({
-    // 쿼리 키: 카테고리가 변경될 때마다 다른 쿼리로 인식
-    queryKey: ['notices', selectedCategory || undefined],
-
-    // 실제 데이터를 가져오는 함수
+    queryKey: ['notices_algolia', selectedCategory || undefined, limitCount],
     queryFn: async ({ pageParam }) => {
-      const result = await fetchNoticesFromFirestore({
-        pageParam,
+      const page = typeof pageParam === 'number' ? pageParam : 0
+      const result = await fetchNoticesFromAlgolia({
+        page,
         category: selectedCategory || undefined,
-        limitCount,
+        hitsPerPage: limitCount,
       })
-
       return result
     },
-
-    // 초기 페이지 파라미터 (undefined는 첫 페이지)
-    initialPageParam: undefined as DocumentData | undefined,
-
-    // 다음 페이지 파라미터를 결정하는 함수
-    getNextPageParam: (lastPage) => lastPage.nextCursor,
-
-    // 캐시 설정
-    staleTime: 10 * 60 * 1000, // 10분
-
-    // 가비지 컬렉션 시간
-    gcTime: 30 * 60 * 1000, // 30분
-
-    // 캐시가 있으면 사용 (queryClient 설정과 통일)
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => lastPage.nextPage,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
     refetchOnMount: false,
-
-    // 앱 포커스 시 리페치 방지 (배터리 절약)
     refetchOnWindowFocus: false,
-
-    // 네트워크 재연결 시 리페치 방지
     refetchOnReconnect: false,
   })
 }

--- a/src/store/notificationCacheStore.ts
+++ b/src/store/notificationCacheStore.ts
@@ -1,0 +1,144 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+
+import { PushNotificationItem } from '@/types/notification.type'
+
+// 알림 조회 스코프: 전체/안읽음
+export type NotificationScope = 'all' | 'unread'
+
+// 페이지네이션 커서 메타정보
+type CursorMeta = {
+  lastCreatedAt?: number | null
+  lastId?: string | null
+}
+
+// 스코프별 캐시 데이터 구조
+type ScopeCache = {
+  items: PushNotificationItem[] // 알림 아이템 배열
+  cursor: CursorMeta // 페이지네이션 커서
+  cachedAt: number | null // 캐시 시각 (ms)
+}
+
+// 알림 캐시 스토어 상태 및 액션
+type NotificationCacheState = {
+  token: string | null // FCM 토큰
+  version: number // 캐시 버전
+  scopes: Record<NotificationScope, ScopeCache> // 스코프별 캐시
+  setToken: (token: string | null) => void // 토큰 설정
+  hydrateScope: (scope: NotificationScope, data: Partial<ScopeCache>) => void // 스코프 부분 업데이트
+  setScopeData: (
+    scope: NotificationScope,
+    items: PushNotificationItem[],
+    cursor: CursorMeta,
+    now?: number
+  ) => void // 스코프 데이터 전체 교체
+  appendScopeData: (
+    scope: NotificationScope,
+    items: PushNotificationItem[],
+    cursor: CursorMeta,
+    now?: number
+  ) => void // 스코프 데이터 추가 (페이지네이션)
+  updateItem: (
+    scope: NotificationScope,
+    id: string,
+    patch: Partial<PushNotificationItem>
+  ) => void // 특정 아이템 부분 업데이트
+  removeItem: (scope: NotificationScope, id: string) => void // 특정 아이템 삭제
+  clearAll: () => void // 전체 캐시 초기화
+}
+
+// 스코프 초기값 생성 함수
+const initialScope = (): ScopeCache => ({
+  items: [],
+  cursor: { lastCreatedAt: null, lastId: null },
+  cachedAt: null,
+})
+
+// 알림 캐시 스토어 (AsyncStorage 영구 저장)
+export const useNotificationCacheStore = create<NotificationCacheState>()(
+  persist(
+    (set) => ({
+      token: null,
+      version: 1,
+      scopes: {
+        all: initialScope(),
+        unread: initialScope(),
+      },
+      // 토큰 설정
+      setToken: (token) => set({ token }),
+      // 스코프 데이터 부분 하이드레이트 (SWR 패턴용)
+      hydrateScope: (scope, data) =>
+        set((state) => ({
+          scopes: {
+            ...state.scopes,
+            [scope]: {
+              items: data.items ?? state.scopes[scope].items,
+              cursor: data.cursor ?? state.scopes[scope].cursor,
+              cachedAt: data.cachedAt ?? state.scopes[scope].cachedAt,
+            },
+          },
+        })),
+      // 스코프 데이터 전체 교체 (초기 로드)
+      setScopeData: (scope, items, cursor, now = Date.now()) =>
+        set((state) => ({
+          scopes: {
+            ...state.scopes,
+            [scope]: { items, cursor, cachedAt: now },
+          },
+        })),
+      // 스코프 데이터 추가 (페이지네이션)
+      appendScopeData: (scope, items, cursor, now = Date.now()) =>
+        set((state) => ({
+          scopes: {
+            ...state.scopes,
+            [scope]: {
+              items: [...state.scopes[scope].items, ...items],
+              cursor,
+              cachedAt: now,
+            },
+          },
+        })),
+      // 특정 아이템 부분 업데이트 (읽음 처리 등)
+      updateItem: (scope, id, patch) =>
+        set((state) => ({
+          scopes: {
+            ...state.scopes,
+            [scope]: {
+              ...state.scopes[scope],
+              items: state.scopes[scope].items.map((x) =>
+                x.id === id ? { ...x, ...patch } : x
+              ),
+            },
+          },
+        })),
+      // 특정 아이템 삭제
+      removeItem: (scope, id) =>
+        set((state) => ({
+          scopes: {
+            ...state.scopes,
+            [scope]: {
+              ...state.scopes[scope],
+              items: state.scopes[scope].items.filter((x) => x.id !== id),
+            },
+          },
+        })),
+      // 전체 캐시 초기화
+      clearAll: () =>
+        set({
+          token: null,
+          scopes: { all: initialScope(), unread: initialScope() },
+        }),
+    }),
+    {
+      name: 'notification-cache-v1',
+      storage: createJSONStorage(() => AsyncStorage),
+      // 액션 함수는 제외하고 상태만 영구 저장
+      partialize: (state) => ({
+        token: state.token,
+        version: state.version,
+        scopes: state.scopes,
+      }),
+    }
+  )
+)


### PR DESCRIPTION
## 📝설명
해당 RP은 Algolia 공지 데이터 마이그레이션 및 알림 리스트 구조 개선 및 캐싱처리를 했습니다.

### 📍구현 범위
- **공지 데이터 소스 Firestore → Algolia로 교체**
  - Algolia 환경변수 설정 및 검증 추가
- **알림 리스트 구조 FlatList로 변경 및 페이지네이션(인피니티 훅) 적용**
  - 알림 캐시 관리(store/zustand) 기능 추가
- **Expo config를 app.json에서 app.config.ts로 마이그레이션**
- **기타 UI/UX 개선 및 코드 리팩터링**