### PR TITLE
feat: network-exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@expo/vector-icons": "^15.0.2",
     "@gorhom/bottom-sheet": "^5.2.6",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/netinfo": "^11.4.1",
     "@react-navigation/drawer": "^7.5.8",
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: 2.2.0
         version: 2.2.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
+      '@react-native-community/netinfo':
+        specifier: ^11.4.1
+        version: 11.4.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))
       '@react-navigation/drawer':
         specifier: ^7.5.8
         version: 7.5.8(@react-navigation/native@7.1.17(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native-gesture-handler@2.28.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native-reanimated@4.1.2(@babel/core@7.28.4)(react-native-worklets@0.5.1(@babel/core@7.28.4)(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0))(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))(react@19.1.0)
@@ -1575,6 +1578,11 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-community/netinfo@11.4.1':
+    resolution: {integrity: sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==}
+    peerDependencies:
+      react-native: '>=0.59'
 
   '@react-native/assets-registry@0.81.4':
     resolution: {integrity: sha512-AMcDadefBIjD10BRqkWw+W/VdvXEomR6aEZ0fhQRAv7igrBzb4PTn4vHKYg+sUK0e3wa74kcMy2DLc/HtnGcMA==}
@@ -7333,6 +7341,10 @@ snapshots:
   '@react-native-async-storage/async-storage@2.2.0(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))':
     dependencies:
       merge-options: 3.0.4
+      react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
+
+  '@react-native-community/netinfo@11.4.1(react-native@0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0))':
+    dependencies:
       react-native: 0.81.4(@babel/core@7.28.4)(@types/react@19.1.13)(react@19.1.0)
 
   '@react-native/assets-registry@0.81.4': {}

--- a/src/app/(settings)/open-source-licenses/index.tsx
+++ b/src/app/(settings)/open-source-licenses/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 
 import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
 import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
@@ -103,7 +104,7 @@ export default function OpenSourceLicensesScreen() {
   }
 
   return (
-    <View className="flex-1 bg-gray-50">
+    <SafeAreaView className="flex-1 bg-white">
       <SettingDetailHeader title="오픈소스 라이선스" />
 
       <ScrollView
@@ -151,6 +152,6 @@ export default function OpenSourceLicensesScreen() {
         url={browserUrl}
         onClose={handleCloseBrowser}
       />
-    </View>
+    </SafeAreaView>
   )
 }

--- a/src/app/(settings)/privacy-policy/index.tsx
+++ b/src/app/(settings)/privacy-policy/index.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'expo-router'
 import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
 
@@ -11,7 +12,7 @@ export default function PrivacyPolicyScreen() {
   }
 
   return (
-    <View className="flex-1 bg-gray-50">
+    <SafeAreaView className="flex-1 bg-white">
       <SettingDetailHeader title="개인정보 처리방침" />
 
       <ScrollView
@@ -82,6 +83,6 @@ export default function PrivacyPolicyScreen() {
           </View>
         </View>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   )
 }

--- a/src/app/(settings)/suggestion/index.tsx
+++ b/src/app/(settings)/suggestion/index.tsx
@@ -14,10 +14,12 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
 import { db } from '@/config/firebaseConfig'
-import { showSuccessToast } from '@/utils/toastUtils'
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+import { showInfoToast, showSuccessToast } from '@/utils/toastUtils'
 
 const suggestionTypes = [
   {
@@ -72,6 +74,7 @@ export default function SuggestionScreen() {
   const [content, setContent] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [step, setStep] = useState<1 | 2>(1)
+  const { isOnline } = useInternetStatus()
 
   // 화면 재진입 시 항상 STEP 1부터 시작
   useFocusEffect(
@@ -83,6 +86,15 @@ export default function SuggestionScreen() {
 
   // 건의사항 전송
   const handleSubmit = async () => {
+    // 오프라인이면 전송 차단 + 토스트
+    if (isOnline === false) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '네트워크 연결 후 다시 시도해 주세요.'
+      )
+      return
+    }
+
     setIsSubmitting(true)
 
     try {
@@ -104,7 +116,7 @@ export default function SuggestionScreen() {
   }
 
   return (
-    <View className="flex-1 bg-gray-50">
+    <SafeAreaView className="flex-1 bg-white">
       <SettingDetailHeader title="건의하기" />
 
       <KeyboardAvoidingView
@@ -236,6 +248,6 @@ export default function SuggestionScreen() {
           )}
         </ScrollView>
       </KeyboardAvoidingView>
-    </View>
+    </SafeAreaView>
   )
 }

--- a/src/app/(settings)/terms-of-service/index.tsx
+++ b/src/app/(settings)/terms-of-service/index.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'expo-router'
 import { ScrollView, View, Text, TouchableOpacity } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 
 import SettingDetailHeader from '@/components/layout/SettingDetailHeader/SettingDetailHeader'
 
@@ -11,7 +12,7 @@ export default function TermsOfServiceScreen() {
   }
 
   return (
-    <View className="flex-1 bg-gray-50">
+    <SafeAreaView className="flex-1 bg-white">
       <SettingDetailHeader title="이용 약관" />
 
       <ScrollView
@@ -131,6 +132,6 @@ export default function TermsOfServiceScreen() {
           </View>
         </View>
       </ScrollView>
-    </View>
+    </SafeAreaView>
   )
 }

--- a/src/app/(tabs)/_layout.tsx
+++ b/src/app/(tabs)/_layout.tsx
@@ -9,11 +9,13 @@ import { NotificationHeader } from '@/components/layout/NotificationHeader'
 import { ScrapHeader } from '@/components/layout/ScrapHeader/ScrapHeader'
 import { SettingHeader } from '@/components/layout/SettingHeader/SettingHeader'
 import { UtilHeader } from '@/components/layout/UtilHeader/UtilHeader'
+import { OfflineToastBridge } from '@/components/network/OfflineToastBridge'
 
 export default function TabLayout() {
   return (
     // 안전 영역
     <SafeAreaProvider>
+      <OfflineToastBridge />
       {/* 공통 레이아웃 안에서 페이지 내용이 표시될 위치 */}
       <Tabs
         screenOptions={{

--- a/src/app/(tabs)/setting.tsx
+++ b/src/app/(tabs)/setting.tsx
@@ -1,11 +1,11 @@
-import { SafeAreaView } from 'react-native-safe-area-context'
+import { View } from 'react-native'
 
 import SettingContent from '@/components/setting/SettingContent/SettingContent'
 
 export default function ProfileScreen() {
   return (
-    <SafeAreaView className="mt-[-50px] flex-1 bg-gray-50">
+    <View className="flex-1 bg-gray-50">
       <SettingContent />
-    </SafeAreaView>
+    </View>
   )
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -11,6 +11,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import Toast from 'react-native-toast-message'
 
 import HomeDrawer from '@/components/layout/HomeDrawer/HomeDrawer'
+import { RefetchOnReconnectBridge } from '@/components/network/RefetchOnReconnectBridge'
 import { toastConfig } from '@/components/ui/CustomToast/CustomToast'
 import { useOnboarding } from '@/hooks/useOnboarding'
 import { useAdStore } from '@/store/adStore'
@@ -52,6 +53,7 @@ export default function RootLayout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
         <BottomSheetModalProvider>
+          <RefetchOnReconnectBridge />
           <Drawer
             drawerContent={(props) => <HomeDrawer {...props} />}
             screenOptions={{

--- a/src/app/onboarding/_layout.tsx
+++ b/src/app/onboarding/_layout.tsx
@@ -1,0 +1,20 @@
+import { Stack } from 'expo-router'
+
+import { OfflineFullScreen } from '@/components/network/OfflineFullScreen'
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+
+export default function OnboardingLayout() {
+  const { isOnline, retry, checking } = useInternetStatus()
+
+  if (!isOnline && !checking) {
+    return (
+      <OfflineFullScreen
+        onRetry={() => {
+          void retry()
+        }}
+      />
+    )
+  }
+
+  return <Stack screenOptions={{ headerShown: false }} />
+}

--- a/src/components/layout/SettingDetailHeader/SettingDetailHeader.tsx
+++ b/src/components/layout/SettingDetailHeader/SettingDetailHeader.tsx
@@ -12,7 +12,7 @@ export default function SettingDetailHeader({
   const router = useRouter()
 
   return (
-    <View className="flex-row items-center gap-4 bg-white px-4 pt-20">
+    <View className="flex-row items-center gap-4 bg-white px-4 pb-2">
       <TouchableOpacity onPress={() => router.back()}>
         <Ionicons name="arrow-back" size={24} color="black" />
       </TouchableOpacity>

--- a/src/components/network/OfflineFullScreen.tsx
+++ b/src/components/network/OfflineFullScreen.tsx
@@ -1,0 +1,49 @@
+import { ReactNode } from 'react'
+
+import { Ionicons } from '@expo/vector-icons'
+import { Linking, Text, TouchableOpacity, View } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
+
+type Props = {
+  onRetry: () => void
+  title?: string
+  description?: string
+  footer?: ReactNode
+}
+
+export function OfflineFullScreen({
+  onRetry,
+  title = '인터넷 연결이 필요해요',
+  description = '연결 확인 후 다시 시도해 주세요.',
+  footer,
+}: Props) {
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <View className="flex-1 items-center justify-center px-8">
+        <Ionicons name="cloud-offline" size={64} color="#9CA3AF" />
+        <Text className="mt-6 text-2xl font-bold text-gray-900">{title}</Text>
+        <Text className="mt-2 text-center text-base text-gray-600">
+          {description}
+        </Text>
+
+        <TouchableOpacity
+          className="mt-8 rounded-lg bg-blue-600 px-6 py-3"
+          onPress={onRetry}
+          activeOpacity={0.8}
+        >
+          <Text className="text-base font-semibold text-white">재시도</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="mt-3"
+          onPress={() => Linking.openSettings()}
+          activeOpacity={0.7}
+        >
+          <Text className="text-sm text-blue-600">설정 열기</Text>
+        </TouchableOpacity>
+
+        {footer ? <View className="mt-6">{footer}</View> : null}
+      </View>
+    </SafeAreaView>
+  )
+}

--- a/src/components/network/OfflineToastBridge.tsx
+++ b/src/components/network/OfflineToastBridge.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react'
+
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+import { showInfoToast, showSuccessToast } from '@/utils/toastUtils'
+
+export function OfflineToastBridge() {
+  const { isOnline } = useInternetStatus()
+  const prevOnline = useRef<boolean | null>(null)
+  const hasBeenOffline = useRef<boolean>(false)
+
+  useEffect(() => {
+    if (prevOnline.current === null) {
+      prevOnline.current = Boolean(isOnline)
+      return
+    }
+
+    if (isOnline === false && prevOnline.current !== false) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '온라인이 되면 바로 확인할 수 있어요.'
+      )
+      hasBeenOffline.current = true
+    }
+
+    if (
+      isOnline === true &&
+      prevOnline.current === false &&
+      hasBeenOffline.current === true
+    ) {
+      showSuccessToast('연결이 복구되었어요', '새 데이터가 준비됐어요.')
+    }
+
+    prevOnline.current = Boolean(isOnline)
+  }, [isOnline])
+
+  return null
+}

--- a/src/components/network/RefetchOnReconnectBridge.tsx
+++ b/src/components/network/RefetchOnReconnectBridge.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+import { useRefetchOnReconnect } from '@/hooks/useRefetchOnReconnect'
+import { flushScrapQueue } from '@/utils/scrapSync'
+
+export function RefetchOnReconnectBridge() {
+  useRefetchOnReconnect()
+  const { isOnline } = useInternetStatus()
+
+  useEffect(() => {
+    if (isOnline) {
+      void flushScrapQueue()
+    }
+  }, [isOnline])
+  return null
+}

--- a/src/components/ui/DepatmentBottomSheet/DepatmentBottomSheet.tsx
+++ b/src/components/ui/DepatmentBottomSheet/DepatmentBottomSheet.tsx
@@ -3,7 +3,8 @@ import { useState } from 'react'
 import { View, Text, TouchableOpacity } from 'react-native'
 
 import { DEPARTMENTS_BY_COLLEGE } from '@/constants/collge'
-import { showSuccessToast } from '@/utils/toastUtils'
+import { useNetworkGuard } from '@/hooks/useNetworkGuard'
+import { showInfoToast, showSuccessToast } from '@/utils/toastUtils'
 
 interface DepatmentBottomSheetProps {
   selectedDepartments?: string[]
@@ -38,6 +39,7 @@ export const DepatmentBottomSheet = ({
   )
   const [currentPage, setCurrentPage] = useState(0)
   const itemsPerPage = 7
+  const { ensureOnline } = useNetworkGuard()
 
   const colleges = Object.keys(DEPARTMENTS_BY_COLLEGE)
   const currentCollege =
@@ -78,6 +80,13 @@ export const DepatmentBottomSheet = ({
   }
 
   const handleDepartmentSelect = (departmentId: string) => {
+    if (!ensureOnline()) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '네트워크 연결 후 다시 시도해 주세요.'
+      )
+      return
+    }
     const departmentName = getDepartmentNameById(departmentId, selectedCollege)
 
     let newSelectedDepartments: string[]
@@ -103,8 +112,13 @@ export const DepatmentBottomSheet = ({
   }
 
   const handleComplete = () => {
-    // 선택 완료 처리 로직 - 선택된 학과는 이미 실시간으로 업데이트됨
-    console.log('선택된 학과들:', selectedDepartments)
+    if (!ensureOnline()) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '네트워크 연결 후 다시 시도해 주세요.'
+      )
+      return
+    }
     // 바텀시트만 닫기 (선택 상태는 이미 상위 컴포넌트에 전달됨)
     showSuccessToast('학과 선택이 저장되었어요')
     onComplete?.()
@@ -231,6 +245,13 @@ export const DepatmentBottomSheet = ({
           </Text>
           <TouchableOpacity
             onPress={() => {
+              if (!ensureOnline()) {
+                showInfoToast(
+                  '오프라인 상태입니다',
+                  '네트워크 연결 후 다시 시도해 주세요.'
+                )
+                return
+              }
               const newSelectedDepartments: string[] = []
               setSelectedDepartments(newSelectedDepartments)
               onDepartmentsUpdate?.(newSelectedDepartments) // 상위 컴포넌트에도 전달

--- a/src/components/ui/KeywordBottomSheet/KeyWordBottomSheet.tsx
+++ b/src/components/ui/KeywordBottomSheet/KeyWordBottomSheet.tsx
@@ -7,7 +7,8 @@ import {
   KEYWORD_CATEGORIES,
   type SelectedKeywords,
 } from '@/constants/keyword'
-import { showSuccessToast } from '@/utils/toastUtils'
+import { useNetworkGuard } from '@/hooks/useNetworkGuard'
+import { showInfoToast, showSuccessToast } from '@/utils/toastUtils'
 
 interface KeywordBottomSheetProps {
   selectedKeywords?: SelectedKeywords
@@ -23,10 +24,18 @@ export const KeywordBottomSheet = ({
   const [selectedKeywords, setSelectedKeywords] = useState<SelectedKeywords>(
     initialSelectedKeywords
   )
+  const { ensureOnline } = useNetworkGuard()
 
   const handleKeywordToggle = (
     categoryKey: keyof typeof NOTIFICATION_KEYWORDS
   ) => {
+    if (!ensureOnline()) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '네트워크 연결 후 다시 시도해 주세요.'
+      )
+      return
+    }
     const isCurrentlySelected = selectedKeywords[categoryKey] || false
 
     let newSelectedKeywords: SelectedKeywords
@@ -48,9 +57,13 @@ export const KeywordBottomSheet = ({
   }
 
   const handleComplete = () => {
-    // 선택 완료 처리 로직
-    console.log('선택된 키워드들:', selectedKeywords)
-    // 상위 컴포넌트에 선택된 키워드 전달
+    if (!ensureOnline()) {
+      showInfoToast(
+        '오프라인 상태입니다',
+        '네트워크 연결 후 다시 시도해 주세요.'
+      )
+      return
+    }
     onKeywordsUpdate?.(selectedKeywords)
     showSuccessToast('키워드가 업데이트되었어요')
     onComplete?.()

--- a/src/components/util/UtilContent/UtilContent.tsx
+++ b/src/components/util/UtilContent/UtilContent.tsx
@@ -15,6 +15,7 @@ import { View, Text, TouchableOpacity, ScrollView } from 'react-native'
 import InAppBrowser from '@/components/ui/InAppBrowser/InAppBrowser'
 import { db } from '@/config/firebaseConfig'
 import { quickItem, uniPlan, uniPlanUrl } from '@/constants/utilContent'
+import { useInternetStatus } from '@/hooks/useInternetStatus'
 import { Notice } from '@/types/notice.type'
 import { getFormattedDate } from '@/utils/dateUtils'
 import { calculateDDay } from '@/utils/dDay'
@@ -25,6 +26,7 @@ export const UtilContent = () => {
   const [isLoading, setIsLoading] = useState(true)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [error, setError] = useState<string | null>(null)
+  const { isOnline } = useInternetStatus()
 
   // 인앱 브라우저 상태
   const [browserVisible, setBrowserVisible] = useState(false)
@@ -44,6 +46,11 @@ export const UtilContent = () => {
       const fetchPopularPosts = async () => {
         setIsLoading(true)
         setError(null)
+        if (isOnline === false) {
+          // 오프라인: 네트워크 호출 건너뛰고 로딩 종료
+          setIsLoading(false)
+          return
+        }
         try {
           const noticesRef = collection(db, 'notices')
 
@@ -72,7 +79,7 @@ export const UtilContent = () => {
       }
 
       fetchPopularPosts()
-    }, [])
+    }, [isOnline])
   )
   return (
     <>

--- a/src/hooks/useInternetStatus.ts
+++ b/src/hooks/useInternetStatus.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import NetInfo from '@react-native-community/netinfo'
+
+const REACHABILITY_URL = 'https://clients3.google.com/generate_204'
+const DEFAULT_TIMEOUT_MS = 3000
+
+async function pingReachability(
+  timeoutMs = DEFAULT_TIMEOUT_MS
+): Promise<boolean> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    const res = await fetch(REACHABILITY_URL, {
+      method: 'HEAD',
+      cache: 'no-cache',
+      signal: controller.signal,
+    })
+    clearTimeout(timeout)
+    // 204 혹은 200 범위를 온라인으로 간주
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+export function useInternetStatus() {
+  const [isConnected, setIsConnected] = useState<boolean | null>(null)
+  const [isInternetReachable, setIsInternetReachable] = useState<
+    boolean | null
+  >(null)
+  const [checking, setChecking] = useState<boolean>(false)
+
+  const lastEmittedRef = useRef<boolean | null>(null)
+
+  const computeStatus = useCallback(async () => {
+    setChecking(true)
+    const state = await NetInfo.fetch()
+    const baseConnected = Boolean(state.isConnected)
+    // NetInfo의 isInternetReachable가 undefined일 수 있어 별도 핑 수행
+    const reachable = baseConnected ? await pingReachability() : false
+    setIsConnected(baseConnected)
+    setIsInternetReachable(reachable)
+    setChecking(false)
+    return reachable
+  }, [])
+
+  const retry = useCallback(async () => {
+    return computeStatus()
+  }, [computeStatus])
+
+  useEffect(() => {
+    const unsub = NetInfo.addEventListener(async (state) => {
+      const baseConnected = Boolean(state.isConnected)
+      let reachable: boolean
+      if (!baseConnected) {
+        reachable = false
+      } else if (state.isInternetReachable != null) {
+        reachable = Boolean(state.isInternetReachable)
+        if (!reachable) {
+          // 추가 확인
+          reachable = await pingReachability()
+        }
+      } else {
+        reachable = await pingReachability()
+      }
+
+      setIsConnected(baseConnected)
+      setIsInternetReachable(reachable)
+
+      // 디바운스 동일 상태 반복 방지
+      if (lastEmittedRef.current !== reachable) {
+        lastEmittedRef.current = reachable
+      }
+    })
+
+    void computeStatus()
+    return () => unsub()
+  }, [computeStatus])
+
+  return useMemo(
+    () => ({
+      checking,
+      isConnected,
+      isInternetReachable,
+      isOnline: Boolean(isConnected && isInternetReachable),
+      retry,
+    }),
+    [checking, isConnected, isInternetReachable, retry]
+  )
+}

--- a/src/hooks/useNetworkGuard.ts
+++ b/src/hooks/useNetworkGuard.ts
@@ -1,0 +1,43 @@
+import { useCallback } from 'react'
+
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+import { showInfoToast } from '@/utils/toastUtils'
+
+export function useNetworkGuard(message?: { title?: string; desc?: string }) {
+  const { isOnline } = useInternetStatus()
+
+  const notifyOffline = useCallback(() => {
+    showInfoToast(
+      message?.title ?? '오프라인 상태입니다',
+      message?.desc ?? '네트워크 연결 후 다시 시도해 주세요.'
+    )
+  }, [message?.title, message?.desc])
+
+  const ensureOnline = useCallback(() => {
+    if (isOnline === false) {
+      notifyOffline()
+      return false
+    }
+    return true
+  }, [isOnline, notifyOffline])
+
+  const guardAction = useCallback(
+    <Args extends unknown[]>(fn: (...args: Args) => void) =>
+      (...args: Args) => {
+        if (!ensureOnline()) return
+        fn(...args)
+      },
+    [ensureOnline]
+  )
+
+  const guardAsync = useCallback(
+    <Args extends unknown[], R>(fn: (...args: Args) => Promise<R>) =>
+      async (...args: Args) => {
+        if (!ensureOnline()) return undefined as unknown as R
+        return await fn(...args)
+      },
+    [ensureOnline]
+  )
+
+  return { isOnline: Boolean(isOnline), ensureOnline, guardAction, guardAsync }
+}

--- a/src/hooks/useRefetchOnReconnect.ts
+++ b/src/hooks/useRefetchOnReconnect.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react'
+
+import { useQueryClient } from '@tanstack/react-query'
+
+import { useInternetStatus } from '@/hooks/useInternetStatus'
+
+export function useRefetchOnReconnect() {
+  const { isOnline } = useInternetStatus()
+  const queryClient = useQueryClient()
+  const prevOnline = useRef<boolean>(true)
+
+  useEffect(() => {
+    if (isOnline && prevOnline.current === false) {
+      // 온라인 복귀 시 활성 쿼리만 재요청
+      void queryClient.refetchQueries({ type: 'active' })
+    }
+    prevOnline.current = Boolean(isOnline)
+  }, [isOnline, queryClient])
+}

--- a/src/utils/scrapSync.ts
+++ b/src/utils/scrapSync.ts
@@ -1,0 +1,56 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { doc, increment, updateDoc } from 'firebase/firestore'
+
+import { db } from '@/config/firebaseConfig'
+
+const STORAGE_KEY = 'pendingScrapIncrements'
+
+type PendingOp = {
+  id: string // notice content_hash
+  delta: 1 | -1
+}
+
+async function readQueue(): Promise<PendingOp[]> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as PendingOp[]) : []
+  } catch {
+    return []
+  }
+}
+
+async function writeQueue(queue: PendingOp[]) {
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(queue))
+}
+
+export async function enqueueScrapDelta(id: string, delta: 1 | -1) {
+  const queue = await readQueue()
+  queue.push({ id, delta })
+  await writeQueue(queue)
+}
+
+export async function flushScrapQueue(): Promise<void> {
+  const queue = await readQueue()
+  if (queue.length === 0) return
+
+  // 병합: 같은 id에 대한 다중 연산을 합산하여 최소 호출
+  const merged = new Map<string, number>()
+  for (const { id, delta } of queue) {
+    merged.set(id, (merged.get(id) ?? 0) + delta)
+  }
+
+  // 적용
+  for (const [id, totalDelta] of merged.entries()) {
+    if (!totalDelta) continue
+    try {
+      const ref = doc(db, 'notices', id)
+      await updateDoc(ref, { scrap_count: increment(totalDelta) })
+    } catch (e) {
+      // 실패 시 남겨두기 위해 조기 종료
+      return
+    }
+  }
+
+  // 모두 성공한 경우에만 큐 제거
+  await writeQueue([])
+}


### PR DESCRIPTION
## 📝설명
해당 PR은 네트워크 미연결 시 UX 개선, 온보딩은 온라인 강제, 메인은 토스트/스니펫로 단순화, 오프라인 스크랩 카운트는 큐잉하여 온라인 복귀 시 일괄 반영했습니다.

### 📍변경 사항
- 네트워크 인프라
  - useInternetStatus: HTTP(204) + 훅 추가
  - OfflineToastBridge: 오프라인/복구 토스트 노출(최초 오프라인 경험 이후에만 복구 토스트)
  - 온보딩 레이아웃 가드: 오프라인 시 풀스크린 재시도 화면
- 공통 가드
  - useNetworkGuard: ensureOnline/guardAction/guardAsync 제공
  - 설정 화면/바텀시트(키워드/학과)에서 오프라인 수정 차단
- 홈 탭
  - 무한스크롤: 오프라인 시 스니펫 노출
  - 에러 화면 UI 개선 + “다시 시도” 버튼
  - 풀투리프레시: 오프라인 시 토스트 후 취소
- 스크랩
  - scrapSync: 오프라인 큐 도입, 온라인 복구 시 병합 반영
  - 복구 브리지에서 활성 쿼리 리페치
- 유틸
  - 인기 공지 로딩: 오프라인 시 네트워크 호출 스킵